### PR TITLE
Replace <- with send for elixir v0.12.2

### DIFF
--- a/lib/httpoison.ex
+++ b/lib/httpoison.ex
@@ -26,15 +26,15 @@ defmodule HTTPoison.Base do
       def transformer(target) do
         receive do
           {:hackney_response, id, {:status, code, _reason}} ->
-            target <- HTTPoison.AsyncStatus[id: id, code: process_status_code(code)]
+            send target, HTTPoison.AsyncStatus[id: id, code: process_status_code(code)]
             transformer(target)
           {:hackney_response, id, {:headers, headers}} ->
-            target <- HTTPoison.AsyncHeaders[id: id, headers: process_headers(headers)]
+            send target, HTTPoison.AsyncHeaders[id: id, headers: process_headers(headers)]
             transformer(target)
           {:hackney_response, id, :done} ->
-            target <- HTTPoison.AsyncEnd[id: id]
+            send target, HTTPoison.AsyncEnd[id: id]
           {:hackney_response, id, chunk} ->
-            target <- HTTPoison.AsyncChunk[id: id, chunk: process_response_chunk(chunk)]
+            send target, HTTPoison.AsyncChunk[id: id, chunk: process_response_chunk(chunk)]
             transformer(target)
         end
       end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule HTTPoison.Mixfile do
   def project do
     [ app: :httpoison,
       version: "0.0.2",
-      elixir: "~> 0.12.0",
+      elixir: "~> 0.12.2",
       deps: deps ]
   end
 

--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -73,7 +73,7 @@ defmodule HTTPoisonTest do
       use HTTPoison.Base
 
       def process_url(url) do
-        self <- :ok
+        send self, :ok
         super(url)
       end
     end


### PR DESCRIPTION
Catching up latest v0.12.2 syntax, and also avoiding compile error on v0.12.3-dev.
