### PR TITLE
deal with an empty response body from hackney

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -80,12 +80,20 @@ defmodule HTTPoison.Base do
                               body,
                               hn_options) do
            {:ok, status_code, headers, client} ->
-             {:ok, body} = :hackney.body(client)
-             %HTTPoison.Response {
-               status_code: process_status_code(status_code),
-               headers: process_headers(headers),
-               body: process_response_body(body)
-             }
+             case :hackney.body(client) do
+               {:ok, body} ->
+                 %HTTPoison.Response {
+                   status_code: process_status_code(status_code),
+                   headers: process_headers(headers),
+                   body: process_response_body(body)
+                 }
+               {:error, {:closed, ""}} ->
+                 %HTTPoison.Response {
+                   status_code: process_status_code(status_code),
+                   headers: process_headers(headers),
+                   body: ""
+                 }
+             end
            {:ok, id} ->
              %HTTPoison.AsyncResponse { id: id }
            {:error, reason} ->


### PR DESCRIPTION
I tried to use httposion for cached get requests using  the "If-Modified-Since" header. Problem is that I get MatchError from within httpoison as soon as I expect a 304 response.

I looked though the source of httpoison and discovered that it can't deal when hackney returns an error code for an empty response body on a get request.

I didn't want to just open an issue although I'm not sure this is the best way to fix this as I'm still trying to get a feel for elixir. Maybe this should even be handled differently in hackney seeing that it does the correct thing if I do a :head request with the same header.

I also could not figure out how the tests are setup and how I could produce such a response in the tests.
