### PR TITLE
expand elixir constraint to include 1.0.0-rc1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ notifications:
 env:
   - ELIXIR="v0.15.0"
   - ELIXIR="v0.15.1"
+  - ELIXIR="v1.0.0-rc1"
 otp_release:
   - 17.0
   - 17.1

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule HTTPoison.Mixfile do
   def project do
     [ app: :httpoison,
       version: "0.4.2",
-      elixir: "~> 0.15.0",
+      elixir: "~> 0.15.0 or ~> 1.0.0-rc1",
       name: "HTTPoison",
       description: @description,
       package: package,


### PR DESCRIPTION
This should cover us until 1.0.0 final hits. There aren't any deprecations or changes to make in httpoison for Elixir 1.0 just yet.

/cc @edgurgel 
