### PR TITLE
[WIP] Support state option to process_ functions

### DIFF
--- a/lib/httpoison.ex
+++ b/lib/httpoison.ex
@@ -4,7 +4,7 @@ defmodule HTTPoison do
   """
 
   defmodule Response do
-    defstruct status_code: nil, body: nil, headers: %{}
+    defstruct status_code: nil, body: nil, headers: %{}, state: nil
     @type t :: %Response{status_code: integer, body: binary, headers: map}
   end
 

--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -11,28 +11,29 @@ defmodule HTTPoison.Base do
       """
       def start, do: :application.ensure_all_started(:httpoison)
 
-      defp process_url(url) do
+      defp process_url(url, state \\ nil) do
         case String.downcase(url) do
           <<"http://"::utf8, _::binary>> -> url
           <<"https://"::utf8, _::binary>> -> url
           _ -> "http://" <> url
         end
       end
+      defp process_request_headers(headers, state \\ nil)
 
-      defp process_request_body(body), do: body
-
-      defp process_response_body(body), do: body
-
-      defp process_request_headers(headers) when is_map(headers) do
+      defp process_request_headers(headers, state) when is_map(headers) do
         Enum.into(headers, [])
       end
-      defp process_request_headers(headers), do: headers
+      defp process_request_headers(headers, state), do: headers
 
-      defp process_response_chunk(chunk), do: chunk
+      defp process_request_body(body, state \\ nil), do: body
 
-      defp process_headers(headers), do: Enum.into(headers, %{})
+      defp process_status_code(status_code, state \\ nil), do: status_code
 
-      defp process_status_code(status_code), do: status_code
+      defp process_headers(headers, state \\ nil), do: Enum.into(headers, %{})
+
+      defp process_response_body(body, state \\ nil), do: body
+
+      defp process_response_chunk(chunk, state \\ nil), do: chunk
 
       @doc false
       @spec transformer(pid) :: :ok
@@ -54,6 +55,20 @@ defmodule HTTPoison.Base do
         end
       end
 
+      defp prepare_request(url, headers, body, :undefined) do
+        {process_url(to_string(url)),
+         process_request_headers(headers),
+         process_request_body(body), :undefined}
+      end
+
+      defp prepare_request(url, headers, body, state) do
+        {request_url, state}     = process_url(to_string(url), state)
+        {request_headers, state} = process_request_headers(headers, state)
+        {request_body, state}    = process_request_body(body, state)
+
+        {request_url, request_headers, request_body, state}
+      end
+
       @doc """
       Sends an HTTP request.
       Args:
@@ -65,6 +80,7 @@ defmodule HTTPoison.Base do
       Options:
         * timeout - timeout in ms, integer
         * stream_to - process id to stream the response
+        * state - state to be passed through process_ functions
 
       Returns {:ok, Response} or {:ok, AsyncResponse} if successful.
       {:error, Error} otherwise.
@@ -74,24 +90,23 @@ defmodule HTTPoison.Base do
       def request(method, url, body \\ "", headers \\ [], options \\ []) do
         timeout = Keyword.get options, :timeout, 5000
         stream_to = Keyword.get options, :stream_to
+        state = Keyword.get options, :state, :undefined
         hn_options = [connect_timeout: timeout] ++ Keyword.get options, :hackney, []
-        body = process_request_body body
 
         if stream_to do
           hn_options = [:async, {:stream_to, spawn(__MODULE__, :transformer, [stream_to])}] ++ hn_options
         end
 
-        case :hackney.request(method,
-                              process_url(to_string(url)),
-                              process_request_headers(headers),
-                              body,
-                              hn_options) do
+        {request_url, request_headers, request_body, state} = prepare_request(url, headers, body, state)
+
+        case :hackney.request(method, request_url, request_headers,
+                              request_body, hn_options) do
           {:ok, status_code, headers, client} when status_code in [204, 304] ->
-            response(status_code, headers, "")
-          {:ok, status_code, headers} -> response(status_code, headers, "")
+            response(status_code, headers, "", state)
+          {:ok, status_code, headers} -> response(status_code, headers, "", state)
           {:ok, status_code, headers, client} ->
             case :hackney.body(client) do
-              {:ok, body} -> response(status_code, headers, body)
+              {:ok, body} -> response(status_code, headers, body, state)
               {:error, reason} -> {:error, %Error{reason: reason} }
             end
           {:ok, id} -> { :ok, %AsyncResponse { id: id } }
@@ -107,12 +122,21 @@ defmodule HTTPoison.Base do
         end
       end
 
-      defp response(status_code, headers, body) do
+      defp response(status_code, headers, body, :undefined) do
         {:ok, %Response {
           status_code: process_status_code(status_code),
           headers: process_headers(headers),
           body: process_response_body(body)
         } }
+      end
+
+      defp response(status_code, headers, body, state) do
+        {status_code, state} = process_status_code(status_code, state)
+        {headers, state}     = process_headers(headers, state)
+        {body, state}        = process_response_body(body, state)
+
+        {:ok, %Response { status_code: status_code, headers: headers,
+                          body: body, state: state } }
       end
 
       @spec get(binary, headers, [{atom, any}]) :: {:ok, Response.t | AsyncResponse.t} | {:error, Error.t}


### PR DESCRIPTION
The request may receive a state kv which will be handled through the
process_* functions on this order:

* process_url
* process_request_headers
* process_request_body

Execute request

* process_status_code
* process_headers
* process_response_body

And the state will be also present on the Response struct. 

What's missing? 

* Adapt Async request
* More tests
* Refactor

A simple example is on the test changed on this PR

It's a proposal to solve the issue https://github.com/edgurgel/httpoison/issues/34 and also a better approach to solve https://github.com/edgurgel/httpoison/issues/23