### PR TITLE
Add support for the :params option in the request function

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -77,6 +77,10 @@ defmodule HTTPoison.Base do
         hn_options = [connect_timeout: timeout] ++ Keyword.get options, :hackney, []
         body = process_request_body body
 
+        if Keyword.has_key?(options, :params) do
+          url = url <> "?" <> URI.encode_query(options[:params])
+        end
+
         if stream_to do
           hn_options = [:async, {:stream_to, spawn(__MODULE__, :transformer, [stream_to])}] ++ hn_options
         end

--- a/mix.exs
+++ b/mix.exs
@@ -20,9 +20,12 @@ defmodule HTTPoison.Mixfile do
   end
 
   defp deps do
-    [ { :hackney, "~> 1.0" },
-      { :httparrot, "~> 0.3.2", only: :test },
-      { :meck, "~> 0.8.2", only: :test } ]
+    [
+      {:hackney, "~> 1.0" },
+      {:exjsx, "~> 3.1", only: :test},
+      {:httparrot, "~> 0.3.2", only: :test},
+      {:meck, "~> 0.8.2", only: :test},
+    ]
   end
 
   defp package do

--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -13,6 +13,16 @@ defmodule HTTPoisonTest do
     end
   end
 
+  test "get with params" do
+    resp = HTTPoison.get("localhost:8080/get", [], params: %{foo: "bar", baz: "bong"})
+    assert_response resp, fn(response) ->
+      args = JSX.decode!(response.body)["args"]
+      assert args["foo"] == "bar"
+      assert args["baz"] == "bong"
+      assert (args |> Dict.keys |> length) == 2
+    end
+  end
+
   test "head" do
     assert_response HTTPoison.head("localhost:8080/get"), fn(response) ->
       assert response.body == ""


### PR DESCRIPTION
As per #29, this adds a `:params` option to the `request` function so that it's possible to do things like:

    HTTPoison.get("/my-url", [], params: %{foo: "bar"})

I only added a test for `GET`ting with parameters, but it actually should work flawlessly with every other method (since it's implemented in the `request` function). AFAIK this is correct behaviour, since you can `POST` to a url using `GET` parameters too.

**PS** I had to add the Poison dependency in order to decode the response body sent by HTTParrot. I hope that's ok since I only added it in the `:test` environment.