### PR TITLE
Add a link to the documentation in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 ![](http://i.imgur.com/WwqN8JO.png)
 # HTTPoison [![Build Status](https://travis-ci.org/edgurgel/httpoison.svg?branch=master)](https://travis-ci.org/edgurgel/httpoison) [![Hex pm](http://img.shields.io/hexpm/v/httpoison.svg?style=flat)](https://hex.pm/packages/httpoison)
 
-HTTP client for Elixir, based on [HTTPotion](https://github.com/myfreeweb/httpotion)
+HTTP client for Elixir, based on
+[HTTPotion](https://github.com/myfreeweb/httpotion)
+([documentation](http://hexdocs.pm/httpoison/)).
 
 ## But... why something so similar to HTTPotion?
 


### PR DESCRIPTION
I added a link to the documentation near the top of the README so it's easy for users to go to the docs from GitHub. Waiting for `0.6.2` to be pushed to hex.pm now :)