### PR TITLE
Documentation for the `HTTPoison` and `HTTPoison.Base` modules

### DIFF
--- a/lib/httpoison.ex
+++ b/lib/httpoison.ex
@@ -1,6 +1,22 @@
 defmodule HTTPoison do
   @moduledoc """
   The HTTP client for Elixir.
+
+  The `HTTPoison` module can be used to issue HTTP requests and parse HTTP responses to arbitrary urls.
+
+      iex> HTTPoison.get!("https://api.github.com")
+      %HTTPoison.Response{status_code: 200,
+                          headers: %{"content-type" => "application/json"},
+                          body: "{...}"}
+
+  It's very common to use HTTPoison in order to wrap APIs, which is when the
+  `HTTPoison.Base` module shines. Visit the documentation for `HTTPoison.Base`
+  for more information.
+
+  Under the hood, the `HTTPoison` module just uses `HTTPoison.Base` (as
+  described in the documentation for `HTTPoison.Base`) without overriding any
+  default function.
+
   """
 
   defmodule Response do

--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -1,4 +1,72 @@
 defmodule HTTPoison.Base do
+  @moduledoc """
+  Provides a default implementation for HTTPoison functions.
+
+  This module is meant to be `use`'d in custom modules in order to wrap the
+  functionalities provided by HTTPoison. For example, this is very useful to
+  build API clients around HTTPoison:
+
+      defmodule GitHub do
+        use HTTPoison.Base
+
+        @endpoint "https://api.github.com"
+
+        defp process_url(url) do
+          @endpoint <> url
+        end
+      end
+
+  The example above shows how the `GitHub` module can wrap HTTPoison
+  functionalities to work with the GitHub API in particular; this way, for
+  example, all requests done through the `GitHub` module will be done to the
+  GitHub API:
+
+      GitHub.get("/users/octocat/orgs")
+      #=> will issue a GET request at https://api.github.com/users/octocat/orgs
+
+  ## Overriding functions
+
+  `HTTPoison.Base` defines the following list of functions, all of which can be
+  overridden (by redefining them). The following list also shows the typespecs
+  for these functions and a short description.
+
+      # Called in order to process the url passed to any request method before
+      # actually issuing the request.
+      @spec process_url(binary) :: binary
+      defp process_url(url)
+
+      # Called to arbitrarly process the request body before sending it with the
+      # request.
+      @spec process_request_body(term) :: binary
+      defp process_request_body(body)
+
+      # Called to arbitrarly process the request headers before sending them
+      # with the request.
+      @spec process_request_headers(term) :: [{binary, term}]
+      defp process_request_headers(headers)
+
+      # Called before returning the response body returned by a request to the
+      # caller.
+      @spec process_response_body(binary) :: term
+      defp process_response_body(body)
+
+      # Used when an async request is made; it's called on each chunk that gets
+      # streamed before returning it to the streaming destination.
+      @spec process_response_chunk(binary) :: term
+      defp process_response_chunk(chunk)
+
+      # Called to process the response headers before returing them to the
+      # caller.
+      @spec process_headers([{binary, term}]) :: term
+      defp process_headers(headers)
+
+      # Used to arbitrarly process the status code of a response before
+      # returning it to the caller.
+      @spec process_status_code(integer) :: term
+      defp process_status_code(status_code)
+
+  """
+
   alias HTTPoison.Response
   alias HTTPoison.AsyncResponse
   alias HTTPoison.Error


### PR DESCRIPTION
I added a `@moduledoc` to the `HTTPoison.Base` module which describes all the overridable functions and how the `Base` module can be used to wrap HTTPoison. I also added some documentation to the `HTTPoison` module.

Let me know if I can do anything else!