### PR TITLE
use list instead of map for request/response header.

### DIFF
--- a/lib/httpoison.ex
+++ b/lib/httpoison.ex
@@ -6,7 +6,7 @@ defmodule HTTPoison do
 
       iex> HTTPoison.get!("https://api.github.com")
       %HTTPoison.Response{status_code: 200,
-                          headers: %{"content-type" => "application/json"},
+                          headers: [{"content-type", "application/json"}],
                           body: "{...}"}
 
   It's very common to use HTTPoison in order to wrap APIs, which is when the
@@ -20,8 +20,8 @@ defmodule HTTPoison do
   """
 
   defmodule Response do
-    defstruct status_code: nil, body: nil, headers: %{}
-    @type t :: %Response{status_code: integer, body: binary, headers: map}
+    defstruct status_code: nil, body: nil, headers: [] 
+    @type t :: %Response{status_code: integer, body: binary, headers: list}
   end
 
   defmodule AsyncResponse do
@@ -35,8 +35,8 @@ defmodule HTTPoison do
   end
 
   defmodule AsyncHeaders do
-    defstruct id: nil, headers: %{}
-    @type t :: %AsyncHeaders{id: reference, headers: map}
+    defstruct id: nil, headers: []
+    @type t :: %AsyncHeaders{id: reference, headers: list}
   end
 
   defmodule AsyncChunk do

--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -72,7 +72,7 @@ defmodule HTTPoison.Base do
   alias HTTPoison.Error
   defmacro __using__(_) do
     quote do
-      @type headers :: map | [{binary, binary}]
+      @type headers :: [{binary, binary}]
 
       @doc """
       Starts HTTPoison and its dependencies.
@@ -98,7 +98,7 @@ defmodule HTTPoison.Base do
 
       defp process_response_chunk(chunk), do: chunk
 
-      defp process_headers(headers), do: Enum.into(headers, %{})
+      defp process_headers(headers), do: headers
 
       defp process_status_code(status_code), do: status_code
 

--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -59,8 +59,8 @@ defmodule HTTPoisonTest do
 
   test "options" do
     assert_response HTTPoison.options("localhost:8080/get"), fn(response) ->
-      assert response.headers["content-length"] == "0"
-      assert is_binary(response.headers["allow"])
+      assert get_header(response.headers, "content-length") == "0"
+      assert is_binary(get_header(response.headers, "allow"))
     end
   end
 
@@ -121,15 +121,22 @@ defmodule HTTPoisonTest do
     assert_receive %HTTPoison.AsyncHeaders{ id: ^id, headers: headers }, 1_000
     assert_receive %HTTPoison.AsyncChunk{ id: ^id, chunk: _chunk }, 1_000
     assert_receive %HTTPoison.AsyncEnd{ id: ^id }, 1_000
-    assert is_map(headers)
+    assert is_list(headers)
   end
 
   defp assert_response({:ok, response}, function \\ nil) do
-    assert is_map(response.headers)
+    assert is_list(response.headers)
     assert response.status_code == 200
-    assert response.headers["connection"] == "keep-alive"
+    assert get_header(response.headers, "connection") == "keep-alive"
     assert is_binary(response.body)
 
     unless function == nil, do: function.(response)
+  end
+
+  defp get_header(headers, key) do
+    headers 
+    |> Enum.filter(fn({k, v}) -> k == key end)
+    |> hd
+    |> elem(1)
   end
 end


### PR DESCRIPTION
According to [rfc2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2), http request/response headers could contain duplicate keys. Such usage could be found in "Cache-Control", "Set-Cookie", "DAV", etc. So here for request/response headers we should not use map (though for request header, user can pass a map if it doesn't contain duplicate keys)though for request header, user can pass a map if it doesn't contain duplicate keys. This fix changes the map to list (the implementation of hackney is correct).

While the bad news is, to make this change, any existing applications using HTTPoison has to change as well...