### PR TITLE
Support recv_timeout as hackney option, default :infinity

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -175,10 +175,11 @@ defmodule HTTPoison.Base do
 
       defp build_hackney_options(options) do
         timeout = Keyword.get options, :timeout, 5000
+        recv_timeout = Keyword.get options, :recv_timeout, :infinity
         stream_to = Keyword.get options, :stream_to
         proxy = Keyword.get options, :proxy
 
-        hn_options = [connect_timeout: timeout] ++ Keyword.get options, :hackney, []
+        hn_options = [connect_timeout: timeout, recv_timeout: recv_timeout] ++ Keyword.get options, :hackney, []
 
         if stream_to do
           hn_options = [:async, {:stream_to, spawn(__MODULE__, :transformer, [stream_to])}] ++ hn_options

--- a/test/httpoison_base_test.exs
+++ b/test/httpoison_base_test.exs
@@ -29,7 +29,7 @@ defmodule HTTPoisonBaseTest do
   end
 
   test "request body using Example" do
-    expect(:hackney, :request, [{[:post, "http://localhost", {:req_headers, []}, {:req_body, "body"}, [connect_timeout: 5000]],
+    expect(:hackney, :request, [{[:post, "http://localhost", {:req_headers, []}, {:req_body, "body"}, [connect_timeout: 5000, recv_timeout: :infinity]],
                                  {:ok, 200, "headers", :client}}])
     expect(:hackney, :body, 1, {:ok, "response"})
 
@@ -42,7 +42,7 @@ defmodule HTTPoisonBaseTest do
   end
 
   test "request body using ExampleDefp" do
-    expect(:hackney, :request, [{[:post, "http://localhost", {:req_headers, []}, {:req_body, "body"}, [connect_timeout: 5000]],
+    expect(:hackney, :request, [{[:post, "http://localhost", {:req_headers, []}, {:req_body, "body"}, [connect_timeout: 5000, recv_timeout: :infinity]],
                                  {:ok, 200, "headers", :client}}])
     expect(:hackney, :body, 1, {:ok, "response"})
 

--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -134,8 +134,8 @@ defmodule HTTPoisonTest do
   end
 
   defp get_header(headers, key) do
-    headers 
-    |> Enum.filter(fn({k, v}) -> k == key end)
+    headers
+    |> Enum.filter(fn({k, _}) -> k == key end)
     |> hd
     |> elem(1)
   end


### PR DESCRIPTION
Simply be able to pass the `recv_timeout` option to `:hackney`. Also keep the same `:infinity` default that `:hackney` has.

Thanks!

