### PR TITLE
Allow request intercept/override

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -65,6 +65,12 @@ defmodule HTTPoison.Base do
       @spec process_status_code(integer) :: term
       defp process_status_code(status_code)
 
+      # Used to intercept http requests and their responses (including all
+      # above overrides to both the request and response).  Use
+      # `base_execute_request/5` to perform the base behavior
+      @spec request(atom, binary, headers, binary, [{atom, any}]) ::
+         {:ok, Response.t | AsyncResponse.t} | {:error, Error.t}
+      defp execute_request(method, url, headers, body, hn_options)
   """
 
   alias HTTPoison.Response

--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -157,9 +157,18 @@ defmodule HTTPoison.Base do
         if Keyword.has_key?(options, :params) do
           url = url <> "?" <> URI.encode_query(options[:params])
         end
+        execute_request(method,
+                        process_url(to_string(url)),
+                        process_request_headers(headers),
+                        body, hn_options)
+      end
 
-        case :hackney.request(method, process_url(to_string(url)), process_request_headers(headers),
-                              body, hn_options) do
+      defp execute_request(method, url, headers, body, hn_options) do
+        base_execute_request(method, url, headers, body, hn_options)
+      end
+
+      defp base_execute_request(method, url, headers, body, hn_options) do
+        case :hackney.request(method, url, headers, body, hn_options) do
           {:ok, status_code, headers, client} when status_code in [204, 304] ->
             response(status_code, headers, "")
           {:ok, status_code, headers} -> response(status_code, headers, "")
@@ -170,7 +179,7 @@ defmodule HTTPoison.Base do
             end
           {:ok, id} -> { :ok, %AsyncResponse { id: id } }
           {:error, reason} -> {:error, %Error{reason: reason}}
-         end
+        end
       end
 
       defp build_hackney_options(options) do

--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -67,7 +67,7 @@ defmodule HTTPoison.Base do
 
       # Used to intercept http requests and their responses (including all
       # above overrides to both the request and response).  Use
-      # `base_execute_request/5` to perform the base behavior
+      # `super` to perform the base behavior
       @spec request(atom, binary, headers, binary, [{atom, any}]) ::
          {:ok, Response.t | AsyncResponse.t} | {:error, Error.t}
       defp execute_request(method, url, headers, body, hn_options)
@@ -169,11 +169,8 @@ defmodule HTTPoison.Base do
                         body, hn_options)
       end
 
-      defp execute_request(method, url, headers, body, hn_options) do
-        base_execute_request(method, url, headers, body, hn_options)
-      end
 
-      defp base_execute_request(method, url, headers, body, hn_options) do
+      defp execute_request(method, url, headers, body, hn_options) do
         case :hackney.request(method, url, headers, body, hn_options) do
           {:ok, status_code, headers, client} when status_code in [204, 304] ->
             response(status_code, headers, "")


### PR DESCRIPTION
There might be a better way to do this.  I needed the ability to intercept a request without changing any of the existing overrides in HTTPoison.Base.  It ends up looking something like this:

```elixir
def execute_request(method, url, request_headers, body, hn_options) do
  {:ok, resp} = base_execute_request(method, url, request_headers, body, hn_options)
  do_stuff_with(method, url, request_headers, body, resp)
  {:ok, resp}
end
```

I'd be glad to try a different approach if anyone has a suggestion.