### PR TITLE
Don't downcase entire string

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -80,9 +80,9 @@ defmodule HTTPoison.Base do
       def start, do: :application.ensure_all_started(:httpoison)
 
       defp process_url(url) do
-        case String.downcase(url) do
-          <<"http://"::utf8, _::binary>> -> url
-          <<"https://"::utf8, _::binary>> -> url
+        case url |> String.slice(0, 8) |> String.downcase do
+          "http://" <> _ -> url
+          "https://" <> _ -> url
           _ -> "http://" <> url
         end
       end


### PR DESCRIPTION
I ran into a VM killer when I (accidentally) passed a 2mb string into `HTTPoison.get`.

Now that's admittedly not a good idea to start with and with the help of @josevalim we found out what was going on: `String.downcase/1` killed the VM for big strings. While that's fixed in master it's still a good idea to only downcase the portion of the string we actually need.

PR attached.