### PR TITLE
Update hackney to 1.1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule HTTPoison.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 1.0"},
+      {:hackney, "~> 1.1.0"},
       {:exjsx, "~> 3.1", only: :test},
       {:httparrot, "~> 0.3.4", only: :test},
       {:meck, "~> 0.8.2", only: :test},


### PR DESCRIPTION
Hackney 1.0 did not include mk-ca-bundle.pl, necessary to generate a new ca-bundle.crt from Mozilla. The bundled ca-bundle.crt in Hackney 1.0 is out of date.