### PR TITLE
Add Ubuntu instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ def application do
 end
 ```
 
+### If you're on Ubuntu
+Make sure you have `erlang-dev` installed before using `httpoison`.
+You can do so by running:
+```sh
+apt-get install erlang-dev
+```
+
 ## Usage
 
 ```iex


### PR DESCRIPTION
Ubuntu users might be missing some erlang headers that would cause src/ssl_verify_hostname.erl to fail.

I thought it would be worth adding these instructions to the README file.
This also helps to address: https://github.com/edgurgel/httpoison/issues/46.