### PR TITLE
Update README to show best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ order to build a client for the GitHub API
 defmodule GitHub do
   use HTTPoison.Base
 
+  @expected_fields [
+    :login, :id, :avatar_url, :gravatar_id, :url, :html_url, :followers_url,
+    :following_url, :gists_url, :starred_url, :subscriptions_url,
+    :organizations_url, :repos_url, :events_url, :received_events_url, :type,
+    :site_admin, :name, :company, :blog, :location, :email, :hireable, :bio,
+    :public_repos, :public_gists, :followers, :following, :created_at, :updated_at
+  ]
+
   def process_url(url) do
     "https://api.github.com" <> url
   end
@@ -86,7 +94,8 @@ defmodule GitHub do
   def process_response_body(body) do
     body
     |> Poison.decode!
-    |> Enum.map(fn({k, v}) -> {String.to_atom(k), v} end)
+    |> Dict.slice(@expected_fields)
+    |> Enum.map(fn({k, v}) -> {String.to_existing_atom(k), v} end)
   end
 end
 ```


### PR DESCRIPTION
Mapping external input to atoms is dangerous since they never get garbaged collected.

Even in simple examples, I think we should provide the safer option.