### PR TITLE
Filter out keys first

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ order to build a client for the GitHub API
 defmodule GitHub do
   use HTTPoison.Base
 
-  @expected_fields [
-    :login, :id, :avatar_url, :gravatar_id, :url, :html_url, :followers_url,
-    :following_url, :gists_url, :starred_url, :subscriptions_url,
-    :organizations_url, :repos_url, :events_url, :received_events_url, :type,
-    :site_admin, :name, :company, :blog, :location, :email, :hireable, :bio,
-    :public_repos, :public_gists, :followers, :following, :created_at, :updated_at
-  ]
+  @expected_fields ~w(
+    login id avatar_url gravatar_id url html_url followers_url
+    following_url gists_url starred_url subscriptions_url
+    organizations_url repos_url events_url received_events_url type
+    site_admin name company blog location email hireable bio
+    public_repos public_gists followers following created_at updated_at
+  )
 
   def process_url(url) do
     "https://api.github.com" <> url
@@ -94,8 +94,8 @@ defmodule GitHub do
   def process_response_body(body) do
     body
     |> Poison.decode!
-    |> Enum.map(fn({k, v}) -> {String.to_existing_atom(k), v} end)
     |> Dict.take(@expected_fields)
+    |> Enum.map(fn({k, v}) -> {String.to_atom(k), v} end)
   end
 end
 ```


### PR DESCRIPTION
Filter out keys first then no need to use `String.to_existing_atom`, because the keys are exactly what we need.