### PR TITLE
Accept proxy_auth parameter for hackney library

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -178,11 +178,15 @@ defmodule HTTPoison.Base do
         recv_timeout = Keyword.get options, :recv_timeout
         stream_to = Keyword.get options, :stream_to
         proxy = Keyword.get options, :proxy
+        proxy_auth = Keyword.get options, :proxy_auth
+
         hn_options = Keyword.get options, :hackney, []
 
         if timeout, do: hn_options = [{:connect_timeout, timeout} | hn_options]
         if recv_timeout, do: hn_options = [{:recv_timeout, recv_timeout} | hn_options]
         if proxy, do: hn_options = [{:proxy, proxy} | hn_options]
+        if proxy_auth, do: hn_options = [{:proxy_auth, proxy_auth} | hn_options]
+
         if stream_to do
           hn_options = [:async, {:stream_to, spawn(__MODULE__, :transformer, [stream_to])} | hn_options]
         end

--- a/test/httpoison_base_test.exs
+++ b/test/httpoison_base_test.exs
@@ -107,7 +107,7 @@ defmodule HTTPoisonBaseTest do
   end
 
   test "passing proxy option with proxy_auth" do
-    expect(:hackney, :request, [{[:post, "http://localhost", [], "body", [proxy: "proxy", proxy_auth: {"username", "password"}]],
+    expect(:hackney, :request, [{[:post, "http://localhost", [], "body", [proxy_auth: {"username", "password"}, proxy: "proxy"]],
                                  {:ok, 200, "headers", :client}}])
     expect(:hackney, :body, 1, {:ok, "response"})
 

--- a/test/httpoison_base_test.exs
+++ b/test/httpoison_base_test.exs
@@ -105,4 +105,17 @@ defmodule HTTPoisonBaseTest do
 
     assert validate :hackney
   end
+
+  test "passing proxy option with proxy_auth" do
+    expect(:hackney, :request, [{[:post, "http://localhost", [], "body", [proxy: "proxy", proxy_auth: {"username", "password"}]],
+                                 {:ok, 200, "headers", :client}}])
+    expect(:hackney, :body, 1, {:ok, "response"})
+
+    assert HTTPoison.post!("localhost", "body", [], [proxy: "proxy", proxy_auth: {"username", "password"}]) ==
+    %HTTPoison.Response{ status_code: 200,
+                         headers: "headers",
+                         body: "response" }
+
+    assert validate :hackney
+  end
 end


### PR DESCRIPTION
Hi there!  The proxy I would like to use requires authentication, and I would like to be able to pass along the proxy_auth parameter which hackney accepts as {'Username', 'Password'}.

Works great on my fork.
Thanks for your consideration!