### PR TITLE
Allow request options override

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -96,6 +96,8 @@ defmodule HTTPoison.Base do
       end
       defp process_request_headers(headers), do: headers
 
+      defp process_request_options(options), do: options
+
       defp process_response_chunk(chunk), do: chunk
 
       defp process_headers(headers), do: headers
@@ -191,7 +193,7 @@ defmodule HTTPoison.Base do
           hn_options = [:async, {:stream_to, spawn(__MODULE__, :transformer, [stream_to])} | hn_options]
         end
 
-        hn_options
+        process_request_options(hn_options)
       end
 
       @doc """

--- a/test/httpoison_base_test.exs
+++ b/test/httpoison_base_test.exs
@@ -7,6 +7,7 @@ defmodule HTTPoisonBaseTest do
     def process_url(url), do: "http://" <> url
     def process_request_body(body), do: {:req_body, body}
     def process_request_headers(headers), do: {:req_headers, headers}
+    def process_request_options(options), do: options
     def process_response_body(body), do: {:resp_body, body}
     def process_headers(headers), do: {:headers, headers}
     def process_status_code(code), do: {:code, code}
@@ -17,6 +18,7 @@ defmodule HTTPoisonBaseTest do
     defp process_url(url), do: "http://" <> url
     defp process_request_body(body), do: {:req_body, body}
     defp process_request_headers(headers), do: {:req_headers, headers}
+    defp process_request_options(options), do: options
     defp process_response_body(body), do: {:resp_body, body}
     defp process_headers(headers), do: {:headers, headers}
     defp process_status_code(code), do: {:code, code}


### PR DESCRIPTION
This is more like a first draft and might need some discussion. Basic idea behind this: Allow for altering request options when extending the HTTPoison.Base, e.g. for pinning a certificate.