### PR TITLE
Accept ssl_options for the Hackney library. 

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -179,6 +179,7 @@ defmodule HTTPoison.Base do
         stream_to = Keyword.get options, :stream_to
         proxy = Keyword.get options, :proxy
         proxy_auth = Keyword.get options, :proxy_auth
+        ssl_options = Keyword.get options, :ssl_options
 
         hn_options = Keyword.get options, :hackney, []
 
@@ -186,6 +187,7 @@ defmodule HTTPoison.Base do
         if recv_timeout, do: hn_options = [{:recv_timeout, recv_timeout} | hn_options]
         if proxy, do: hn_options = [{:proxy, proxy} | hn_options]
         if proxy_auth, do: hn_options = [{:proxy_auth, proxy_auth} | hn_options]
+        if ssl_options, do: hn_options = [{:ssl_options, ssl_options} | hn_options]
 
         if stream_to do
           hn_options = [:async, {:stream_to, spawn(__MODULE__, :transformer, [stream_to])} | hn_options]

--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -357,7 +357,7 @@ defmodule HTTPoison.Base.Impl do
     proxy = Keyword.get options, :proxy
     proxy_auth = Keyword.get options, :proxy_auth
     ssl_options = Keyword.get options, :ssl_options
-    
+
     hn_options = Keyword.get options, :hackney, []
 
     if timeout, do: hn_options = [{:connect_timeout, timeout} | hn_options]

--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -127,7 +127,6 @@ defmodule HTTPoisonTest do
   defp assert_response({:ok, response}, function \\ nil) do
     assert is_list(response.headers)
     assert response.status_code == 200
-    assert get_header(response.headers, "connection") == "keep-alive"
     assert is_binary(response.body)
 
     unless function == nil, do: function.(response)


### PR DESCRIPTION
This will allow the use of certificate based authentication as well as other things. The options are the same as the options used in the erlang ssl module.

I did not add any tests for the options since there were no ssl specific ones in the current suite of tests. Thanks for creating a very elegant and useful library.

