### PR TITLE
pass url to process_request_headers callback

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -42,8 +42,8 @@ defmodule HTTPoison.Base do
 
       # Called to arbitrarly process the request headers before sending them
       # with the request.
-      @spec process_request_headers(term) :: [{binary, term}]
-      defp process_request_headers(headers)
+      @spec process_request_headers(term, binary) :: [{binary, term}]
+      defp process_request_headers(headers, url)
 
       # Called before returning the response body returned by a request to the
       # caller.
@@ -88,10 +88,10 @@ defmodule HTTPoison.Base do
 
       defp process_response_body(body), do: body
 
-      defp process_request_headers(headers) when is_map(headers) do
+      defp process_request_headers(headers, url) when is_map(headers) do
         Enum.into(headers, [])
       end
-      defp process_request_headers(headers), do: headers
+      defp process_request_headers(headers, url), do: headers
 
       defp process_response_chunk(chunk), do: chunk
 
@@ -150,7 +150,7 @@ defmodule HTTPoison.Base do
         end
         url = process_url(to_string(url))
         body = process_request_body(body)
-        headers = process_request_headers(headers)
+        headers = process_request_headers(headers, url)
         HTTPoison.Base.request(__MODULE__, method, url, body, headers, options, &process_status_code/1, &process_headers/1, &process_response_body/1)
       end
 

--- a/test/httpoison_base_test.exs
+++ b/test/httpoison_base_test.exs
@@ -6,7 +6,7 @@ defmodule HTTPoisonBaseTest do
     use HTTPoison.Base
     def process_url(url), do: "http://" <> url
     def process_request_body(body), do: {:req_body, body}
-    def process_request_headers(headers), do: {:req_headers, headers}
+    def process_request_headers(headers, _url), do: {:req_headers, headers}
     def process_response_body(body), do: {:resp_body, body}
     def process_headers(headers), do: {:headers, headers}
     def process_status_code(code), do: {:code, code}
@@ -16,13 +16,14 @@ defmodule HTTPoisonBaseTest do
     use HTTPoison.Base
     defp process_url(url), do: "http://" <> url
     defp process_request_body(body), do: {:req_body, body}
-    defp process_request_headers(headers), do: {:req_headers, headers}
+    defp process_request_headers(headers, _url), do: {:req_headers, headers}
     defp process_response_body(body), do: {:resp_body, body}
     defp process_headers(headers), do: {:headers, headers}
     defp process_status_code(code), do: {:code, code}
   end
 
   setup do
+    {:ok, _} = :application.ensure_all_started(:httparrot)
     new :hackney
     on_exit fn -> unload end
     :ok
@@ -130,5 +131,12 @@ defmodule HTTPoisonBaseTest do
                          body: "response" }
 
     assert validate :hackney
+  end
+
+  test "url-based headers augmentation" do
+    assert Example.post!("http://localhost/headers", {:form, [token: "secret"]}) ==
+    %HTTPoison.Response{ status_code: 200,
+                         headers: [token: "secret"],
+                         body: ""}
   end
 end


### PR DESCRIPTION
Hello @edgurgel ,

Consider this as WIP. 
The intention is to add ability to process headers accordingly to request url.  
Possible use case: I'm implementing API wrapper which assumes JWT <-> Access Token exchange. For that request there is no not for any kind of headers augmentations, but since `access_token` is acquired it should be injected in the all following requests to the private endpoints. 

I tried to write test in the `test/httpoison_base_test.exs` to TDD this functionality with following steps: 
- add `def process_request_headers(headers, 'http://localhost/headers'), do: {:req_headers, [token: 'secret']}` callback to the `Example` module 
- make request to the `/headers` endpoint
- check that token is returned

Of course downside of this approach that request to the headers will be globally munged, maybe there is a better way? 

This technic mimics those which are used in  `test/httpoison_test.exs`, but probably I'm missing something, because of https://github.com/lessless/httpoison/blob/master/test/httpoison_base_test.exs#L136 is failing with

```elixir
  1) test url-based headers augmentation (HTTPoisonBaseTest)
     test/httpoison_base_test.exs:136
     ** (UndefinedFunctionError) undefined function: :hackney.request/5 (module :hackney is not available)
     stacktrace:
       (hackney) :hackney.request(:post, "http://http://localhost/headers", {:req_headers, []}, {:req_body, {:form, [token: "secret"]}}, [])
       (httpoison) lib/httpoison/base.ex:386: HTTPoison.Base.request/9
       test/httpoison_base_test.exs:6: HTTPoisonBaseTest.Example.request!/5
       test/httpoison_base_test.exs:137

```