### PR TITLE
Fix process leak in async mode / follow_redirect

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -343,7 +343,10 @@ defmodule HTTPoison.Base do
         send target, %Error{id: id, reason: reason}
       {:hackney_response, id, chunk} ->
         send target, %HTTPoison.AsyncChunk{id: id, chunk: process_response_chunk.(chunk)}
-        transformer(module, target, process_status_code, process_headers, process_response_chunk)
+        case chunk do
+          {:redirect, _to, _headers} -> nil
+          _ -> transformer(module, target, process_status_code, process_headers, process_response_chunk)
+        end
     end
   end
 


### PR DESCRIPTION
From Hackney doc:

> Note: if the response is async, only
> `follow_redirect` is take in consideration for the redirection.
> If a valid redirection happen you receive the messages:
> - `{redirect, To, Headers}`
> - `{see_other, To, Headers}` for status 303 POST requests.

It only checks redirection validity but lets the client handle the redirection itself.
That means `HTTPoison.Base.transformer` must not wait for further messages when `{:redirect, ...}` is received. I changed it so that it no longer leaks a process in this case.

Maybe it would be better to introduce an `AsyncRedirect` struct to handle this case or to completely wrap redirect handling so that `follow_redirect: true` is handled the same way in sync and async mode. 