### PR TITLE
Fix async redirect process leak

### DIFF
--- a/lib/httpoison.ex
+++ b/lib/httpoison.ex
@@ -23,6 +23,11 @@ defmodule HTTPoison.AsyncChunk do
   @type t :: %__MODULE__{id: reference, chunk: binary}
 end
 
+defmodule HTTPoison.AsyncRedirect do
+  defstruct id: nil, to: nil, headers: []
+  @type t :: %__MODULE__{id: reference, to: String.t, headers: list}
+end
+
 defmodule HTTPoison.AsyncEnd do
   defstruct id: nil
   @type t :: %__MODULE__{id: reference}

--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -339,6 +339,8 @@ defmodule HTTPoison.Base do
         send target, %HTTPoison.AsyncEnd{id: id}
       {:hackney_response, id, {:error, reason}} ->
         send target, %Error{id: id, reason: reason}
+      {:hackney_response, id, {redirect, to, headers}} when redirect in [:redirect, :see_other] ->
+        send target, %HTTPoison.AsyncRedirect{id: id, to: to, headers: process_headers.(headers)}
       {:hackney_response, id, chunk} ->
         send target, %HTTPoison.AsyncChunk{id: id, chunk: process_response_chunk.(chunk)}
         transformer(module, target, process_status_code, process_headers, process_response_chunk)

--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -129,6 +129,14 @@ defmodule HTTPoisonTest do
     assert is_list(headers)
   end
 
+  test "asynchronous redirected get request" do
+    {:ok, %HTTPoison.AsyncResponse{id: id}} = HTTPoison.get "localhost:8080/redirect/2", [], [stream_to: self, hackney: [follow_redirect: true]]
+
+    assert_receive %HTTPoison.AsyncRedirect{ id: ^id, to: to, headers: headers }, 1_000
+    assert to == "http://localhost:8080/redirect/1"
+    assert is_list(headers)
+  end
+
   defp assert_response({:ok, response}, function \\ nil) do
     assert is_list(response.headers)
     assert response.status_code == 200


### PR DESCRIPTION
Hackney does not follow redirect when using asynchronous requests, it
responds {:redirect | :see_other, new_location, headers} instead and
it's up to the client to manage it itself.

We introduce %HTTPoison.AsyncRedirect{} to cope with that.