### PR TITLE
Add description for the :params option

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -133,6 +133,7 @@ defmodule HTTPoison.Base do
         * `:ssl` - SSL options supported by the `ssl` erlang module
         * `:follow_redirect` - a boolean that causes redirects to be followed
         * `:max_redirect` - an integer denoting the maximum number of redirects to follow
+        * `:params` - an enumerable consisting of two-item tuples that will be appended to the url as query string parameters
 
       Timeouts can be an integer or `:infinity`
 


### PR DESCRIPTION
I hope it is not too verbose and that the description does not introduce inconsistency, as you only describe options at this point which are relevant to `build_hackney_options`.