### PR TITLE
refine overridable functions when using module Base.

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -99,6 +99,16 @@ defmodule HTTPoison.Base do
 
       defp process_status_code(status_code), do: status_code
 
+      defoverridable [
+        process_url: 1,
+        process_request_body: 1,
+        process_response_body: 1,
+        process_request_headers: 1,
+        process_response_chunk: 1,
+        process_headers: 1,
+        process_status_code: 1
+      ]
+
       @doc false
       @spec transformer(pid) :: :ok
       def transformer(target) do
@@ -327,7 +337,6 @@ defmodule HTTPoison.Base do
       @spec options!(binary, headers, Keyword.t) :: Response.t | AsyncResponse.t
       def options!(url, headers \\ [], options \\ []),     do: request!(:options, url, "", headers, options)
 
-      defoverridable Module.definitions_in(__MODULE__)
     end
   end
 


### PR DESCRIPTION
The `defoverridable Module.definitions_in(__MODULE__)` can cause some unexpected behaviors.
Such as, when defining struct in the module using `HTTPoison.Base`,
 the `__struct__ ` function will be lazily defined,
which causes `%__MODULE__{}` cannot function correctly.

``` elixir
defmodule FooBar do
  defmacro __using__(_) do
    quote do
      defoverridable Module.definitions_in(__MODULE__)
      Module.definitions_in(__MODULE__) |> IO.inspect
    end
  end
end

defmodule MyModule do
  defstruct bar: nil
  use FooBar
  def foo(%__MODULE__{bar: bar}), do: bar
end

# ====>
# ** (CompileError) test.ex:17: MyModule.__struct__/0 is undefined, cannot expand struct MyModule
#    (elixir) src/elixir_map.erl:58: :elixir_map.translate_struct/4
#    (stdlib) lists.erl:1353: :lists.mapfoldl/3
```