### PR TITLE
Read the body on all requests to ensure that the socket is closed

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -394,8 +394,6 @@ defmodule HTTPoison.Base do
 
     case :hackney.request(method, request_url, request_headers,
                           request_body, hn_options) do
-      {:ok, status_code, headers, _client} when status_code in [204, 304] ->
-        response(process_status_code, process_headers, process_response_body, status_code, headers, "")
       {:ok, status_code, headers} -> response(process_status_code, process_headers, process_response_body, status_code, headers, "")
       {:ok, status_code, headers, client} ->
         case :hackney.body(client) do


### PR DESCRIPTION
The body wasn't being read in the case of a status code 204 or 304, which meant that hackney was leaving the socket open. I've removed that guard in order to ensure that the sockets aren't left hanging around.

See https://github.com/benoitc/hackney/issues/257#issuecomment-155857498
for more information.