### PR TITLE
bump hackney dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule HTTPoison.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 1.4.4"},
+      {:hackney, "~> 1.5.2"},
       {:exjsx, "~> 3.1", only: :test},
       {:httparrot, "~> 0.3.4", only: :test},
       {:meck, "~> 0.8.2", only: :test},


### PR DESCRIPTION
fixes a rebar.config badmatch error with the latest stable versions of rebar3 and hackney.

https://github.com/benoitc/hackney/issues/294
https://github.com/benoitc/hackney/pull/295
