### PR TITLE
Makes use of Map instead of Dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ defmodule GitHub do
   def process_response_body(body) do
     body
     |> Poison.decode!
-    |> Dict.take(@expected_fields)
+    |> Map.take(@expected_fields)
     |> Enum.map(fn({k, v}) -> {String.to_atom(k), v} end)
   end
 end

--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -19,7 +19,7 @@ defmodule HTTPoisonTest do
       args = JSX.decode!(response.body)["args"]
       assert args["foo"] == "bar"
       assert args["baz"] == "bong"
-      assert (args |> Dict.keys |> length) == 2
+      assert (args |> Map.keys |> length) == 2
     end
   end
 


### PR DESCRIPTION
I would recommend to make use of Map instead of Dict since it has already been soft deprecated.