### PR TITLE
Allow to pass encoded params.

### DIFF
--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -23,6 +23,16 @@ defmodule HTTPoisonTest do
     end
   end
 
+  test "get with serialized params" do
+    resp = HTTPoison.get("localhost:8080/get", [], params: URI.encode_query(%{foo: "bar", baz: "bong"}))
+    assert_response resp, fn(response) ->
+      args = JSX.decode!(response.body)["args"]
+      assert args["foo"] == "bar"
+      assert args["baz"] == "bong"
+      assert (args |> Map.keys |> length) == 2
+    end
+  end
+
   test "head" do
     assert_response HTTPoison.head("localhost:8080/get"), fn(response) ->
       assert response.body == ""


### PR DESCRIPTION
I am trying to send a request with a query as follow:

```
http://example.com?foo[]=1&foo[]=2
```

which is to encode easy using `Plug.Conn.Query.encode`, as `%{foo: [1, 2]}` yields the correct result.
However, it seems to be impossible to pass an already encoded query to `HTTPoison`,
as `URI.encode_query` fails.
Of course, we can append directly to the URL, but as the `params` option already exists,
I think it would be nicer to support this case as well.

This patch keeps the previous behavior when the query is not a binary, and avoid
trying to reencode it when it is already a binary.

Thank you.