### PR TITLE
Catch Hackney errors using '{:error, reason}' tuple format

### DIFF
--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -117,6 +117,13 @@ defmodule HTTPoisonTest do
     end
   end
 
+  test "send an empty url" do
+    assert HTTPoison.get "" == {:error, %HTTPoison.Error{reason: :badarg}}
+    assert_raise HTTPoison.Error, ":badarg", fn ->
+      HTTPoison.get! ""
+    end
+  end
+
   test "asynchronous request" do
     {:ok, %HTTPoison.AsyncResponse{id: id}} = HTTPoison.get "localhost:8080/get", [], [stream_to: self]
 


### PR DESCRIPTION
This will fix https://github.com/edgurgel/httpoison/issues/117

This PR tries to fix the errors raised by Hackney, when we try to send a get request to an empty URL an exception is raised:
```
iex(1)> HTTPoison.get(" ")
** (exit) :badarg
       (kernel) gen_tcp.erl:148: :gen_tcp.connect/4
      (hackney) src/hackney_connect.erl:245: :hackney_connect.do_connect/5
      (hackney) src/hackney_connect.erl:36: :hackney_connect.connect/5
      (hackney) src/hackney.erl:328: :hackney.request/5
    (httpoison) lib/httpoison/base.ex:396: HTTPoison.Base.request/9
```

So, would be nice to return `{:error, reason}` for all these errors.
For example:

```
iex(1)> HTTPoison.get(" ")

{:error, %HTTPoison.Error{id: nil, reason: :badarg}}
```