### PR TITLE
Fixing warnings in mix.exs for elixir 1.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,8 +11,8 @@ defmodule HTTPoison.Mixfile do
       elixir: "~> 1.2",
       name: "HTTPoison",
       description: @description,
-      package: package,
-      deps: deps,
+      package: package(),
+      deps: deps(),
       source_url: "https://github.com/edgurgel/httpoison" ]
   end
 


### PR DESCRIPTION
fixing warnings in mix.exs for dep() and package()