### PR TITLE
Add put method without body

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -208,7 +208,7 @@ defmodule HTTPoison.Base do
       See `request/5` for more detailed information.
       """
       @spec put(binary, body, headers, Keyword.t) :: {:ok, Response.t | AsyncResponse.t } | {:error, Error.t}
-      def put(url, body, headers \\ [], options \\ []),    do: request(:put, url, body, headers, options)
+      def put(url, body \\ "", headers \\ [], options \\ []),    do: request(:put, url, body, headers, options)
 
       @doc """
       Issues a PUT request to the given url, raising an exception in case of
@@ -218,8 +218,8 @@ defmodule HTTPoison.Base do
 
       See `request!/5` for more detailed information.
       """
-      @spec put!(binary, body, headers, Keyword.t) :: Response.t | AsyncResponse.t
-      def put!(url, body, headers \\ [], options \\ []),   do: request!(:put, url, body, headers, options)
+      @spec put!(binary, body, Keyword.t) :: Response.t | AsyncResponse.t
+      def put!(url, body \\ "", headers \\ [], options \\ []),   do: request!(:put, url, body, headers, options)
 
       @doc """
       Issues a HEAD request to the given url.

--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -49,6 +49,10 @@ defmodule HTTPoisonTest do
     assert_response HTTPoison.put("localhost:8080/put", "test")
   end
 
+  test "put without body" do
+    assert_response HTTPoison.put("localhost:8080/put")
+  end
+
   test "patch" do
     assert_response HTTPoison.patch("localhost:8080/patch", "test")
   end


### PR DESCRIPTION
I want to use HTTP PUT without body parameter.
This is an example of the github api.

<img width="663" alt="screen shot 2016-09-18 at 09 44 37" src="https://cloud.githubusercontent.com/assets/2505641/18611897/a22d1cf2-7d84-11e6-9559-60f1f34f5733.png">


The default value of body argument of `HTTPoison.Base.put` method was to `""`.