### PR TITLE
Unix socket support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Unreleased
+
+* Add support for http over unix sockets - requires hackney >= 1.6.3, erlang >= 19. (#185).
+
 # 0.9.2 (2016-09-27)
 
 * Rewrite `request!/5` in a way that does not cause OTP 19 cover to error (#178);

--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -358,9 +358,10 @@ defmodule HTTPoison.Base do
 
   @doc false
   def default_process_url(url) do
-    case url |> String.slice(0, 8) |> String.downcase do
+    case url |> String.slice(0, 12) |> String.downcase do
       "http://" <> _ -> url
       "https://" <> _ -> url
+      "http+unix://" <> _ -> url
       _ -> "http://" <> url
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -22,9 +22,9 @@ defmodule HTTPoison.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 1.6.0"},
+      {:hackney, "~> 1.6.3"},
       {:exjsx, "~> 3.1", only: :test},
-      {:httparrot, "~> 0.4", only: :test},
+      {:httparrot, "~> 0.5", only: :test},
       {:meck, "~> 0.8.2", only: :test},
       {:earmark, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.13", only: :dev},

--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -94,6 +94,17 @@ defmodule HTTPoisonTest do
     assert_response HTTPoison.get("https://localhost:8433/get", [], ssl: [cacertfile: cacert_file, keyfile: key_file, certfile: cert_file])
   end
 
+  test "http+unix scheme" do
+    if Application.get_env(:httparrot, :unix_socket, false) do
+      case {HTTParrot.unix_socket_supported?, Application.fetch_env(:httparrot, :socket_path)} do
+        {true, {:ok, path}} ->
+          path = URI.encode_www_form(path)
+          assert_response HTTPoison.get("http+unix://#{path}/get")
+        _ -> :ok
+      end
+    end
+  end
+
   test "char list URL" do
     assert_response HTTPoison.head('localhost:8080/get')
   end


### PR DESCRIPTION
Allows connecting to http servers listening on unix sockets

To perform a get `/path` on `/var/run/app.sock` (note the required escaping on slashes):

`iex> HTTPoison.get! "http+unix://%2Fvar%2Frun%2Fapp.sock/path"`

**NOTE** requires erlang >= 19 and hackney >= 1.6.2

Closes  #185 