### PR TITLE
Bump `ex_doc` version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule HTTPoison.Mixfile do
       {:httparrot, "~> 0.4", only: :test},
       {:meck, "~> 0.8.2", only: :test},
       {:earmark, "~> 1.0", only: :dev},
-      {:ex_doc, "~> 0.13", only: :dev},
+      {:ex_doc, "~> 0.14.3", only: :dev},
     ]
   end
 


### PR DESCRIPTION
`0.14.3` is the [latest](https://github.com/elixir-lang/ex_doc/releases/tag/v0.14.3) release.