### PR TITLE
Add streaming upload

### DIFF
--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -175,6 +175,17 @@ defmodule HTTPoisonTest do
     assert_response(response)
   end
 
+  test "post streaming body" do
+    expected = %{"some" => "bytes"}
+    enumerable = JSX.encode!(expected) |> String.split("")
+    headers = %{"Content-type" => "application/json"}
+    response = HTTPoison.post("localhost:8080/post", {:stream, enumerable}, headers)
+    assert_response response
+    {:ok, %HTTPoison.Response{body: body}} = response
+
+    assert JSX.decode!(body)["json"] == expected
+  end
+
   defp assert_response({:ok, response}, function \\ nil) do
     assert is_list(response.headers)
     assert response.status_code == 200


### PR DESCRIPTION
* Body for put/post/patch can be a `{:stream, enumerable}`
* Stream.transform puts bytes into the socket lazily,
  halting at the first error and emitting that error

TODO: Not sure what the best way to test a call to `send_body` failing while the stream is being transformed, any thoughts here? Right now there's only a test for the non-failure case. 