### PR TITLE
Fix a tyop in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ end
 There are a number of supported options(*not to be confused with the HTTP options method*), documented [here](https://hexdocs.pm/httpoison/HTTPoison.html#options/3), that can be added to your request. The example below shows the use of the `:ssl` and `:recv_timeout` options for a post request to an api that requires a bearer token. The `:ssl` option allows you to set options accepted by th [Erland SSL module](http://erlang.org/doc/man/ssl.html), and `:recv_timeout` sets a timeout on receiving a response, the default is 5000ms.
 
 ```elixir
-toekn = "some_token_from_another_request"
+token = "some_token_from_another_request"
 url = "https://example.com/api/endpoint_that_needs_a_bearer_token"
 headers = ["Authorization": "Bearer #{token}", "Accept": "Application/json; Charset=utf-8"]
 options = [ssl: [{:versions, [:'tlsv1.2']}], recv_timeout: 500]


### PR DESCRIPTION
Just two characters