### PR TITLE
Add process_request_options/1 to HTTPoison.Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ end
 
 defp process_request_headers(headers), do: headers
 
+defp process_request_options(options), do: options
+
 defp process_response_chunk(chunk), do: chunk
 
 defp process_headers(headers), do: headers

--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -45,6 +45,11 @@ defmodule HTTPoison.Base do
       @spec process_request_headers(term) :: [{binary, term}]
       def process_request_headers(headers)
 
+      # Called to arbitrarily process the request options before sending them
+      # with the request.
+      @spec process_request_options(keyword) :: keyword
+      def process_request_options(options)
+
       # Called before returning the response body returned by a request to the
       # caller.
       @spec process_response_body(binary) :: term
@@ -93,6 +98,8 @@ defmodule HTTPoison.Base do
         Enum.into(headers, [])
       end
       def process_request_headers(headers), do: headers
+
+      def process_request_options(options), do: options
 
       def process_response_chunk(chunk), do: chunk
 
@@ -160,6 +167,7 @@ defmodule HTTPoison.Base do
         url = process_url(to_string(url))
         body = process_request_body(body)
         headers = process_request_headers(headers)
+        options = process_request_options(options)
         HTTPoison.Base.request(__MODULE__, method, url, body, headers, options, &process_status_code/1, &process_headers/1, &process_response_body/1)
       end
 

--- a/test/httpoison_base_test.exs
+++ b/test/httpoison_base_test.exs
@@ -7,6 +7,7 @@ defmodule HTTPoisonBaseTest do
     def process_url(url), do: "http://" <> url
     def process_request_body(body), do: {:req_body, body}
     def process_request_headers(headers), do: {:req_headers, headers}
+    def process_request_options(options), do: Keyword.put(options, :timeout, 10)
     def process_response_body(body), do: {:resp_body, body}
     def process_headers(headers), do: {:headers, headers}
     def process_status_code(code), do: {:code, code}
@@ -17,6 +18,7 @@ defmodule HTTPoisonBaseTest do
     defp process_url(url), do: "http://" <> url
     defp process_request_body(body), do: {:req_body, body}
     defp process_request_headers(headers), do: {:req_headers, headers}
+    defp process_request_options(options), do: Keyword.put(options, :timeout, 10)
     defp process_response_body(body), do: {:resp_body, body}
     defp process_headers(headers), do: {:headers, headers}
     defp process_status_code(code), do: {:code, code}
@@ -29,7 +31,7 @@ defmodule HTTPoisonBaseTest do
   end
 
   test "request body using Example" do
-    expect(:hackney, :request, [{[:post, "http://localhost", {:req_headers, []}, {:req_body, "body"}, []],
+    expect(:hackney, :request, [{[:post, "http://localhost", {:req_headers, []}, {:req_body, "body"}, [{:connect_timeout, 10}]],
                                  {:ok, 200, "headers", :client}}])
     expect(:hackney, :body, 1, {:ok, "response"})
 
@@ -42,7 +44,7 @@ defmodule HTTPoisonBaseTest do
   end
 
   test "request body using ExampleDefp" do
-    expect(:hackney, :request, [{[:post, "http://localhost", {:req_headers, []}, {:req_body, "body"}, []],
+    expect(:hackney, :request, [{[:post, "http://localhost", {:req_headers, []}, {:req_body, "body"}, [{:connect_timeout, 10}]],
                                  {:ok, 200, "headers", :client}}])
     expect(:hackney, :body, 1, {:ok, "response"})
 


### PR DESCRIPTION
I recently found myself wanting to add the `:proxy` option to all requests if a specific env var was present in a deployment environment. I was able to do so by overriding `request` on `HTTPoison.Base`, but I think having an overridable `process_request_options` is a better approach. This PR adds it.

The best testing approach I could come up with was adding the `:timeout` option in the override. I hope this makes sense.