### PR TITLE
Change typespec of Response.body

### DIFF
--- a/lib/httpoison.ex
+++ b/lib/httpoison.ex
@@ -1,6 +1,6 @@
 defmodule HTTPoison.Response do
   defstruct status_code: nil, body: nil, headers: []
-  @type t :: %__MODULE__{status_code: integer, body: binary, headers: list}
+  @type t :: %__MODULE__{status_code: integer, body: term, headers: list}
 end
 
 defmodule HTTPoison.AsyncResponse do
@@ -65,4 +65,3 @@ defmodule HTTPoison do
 
   use HTTPoison.Base
 end
-


### PR DESCRIPTION
Response.body could be `any()` because we set the return value from the function `process_response_body`. For example, if we process JSON response from the server, it could be the `map`. 

Please correct me if I'm wrong. Thanks!