### PR TITLE
properly handle URLs that already contain a query string

### DIFF
--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -24,10 +24,10 @@ defmodule HTTPoisonTest do
   end
 
   test "get with params in url and options" do
-    resp = HTTPoison.get("localhost:8080/get?bar=zing&foo=overridden", [], params: %{foo: "bar", baz: "bong"})
+    resp = HTTPoison.get("localhost:8080/get?bar=zing&foo=first", [], params: [{"foo", "second"}, {"baz", "bong"}])
     assert_response resp, fn(response) ->
       args = JSX.decode!(response.body)["args"]
-      assert args["foo"] == "bar"
+      assert args["foo"] == ["first", "second"]
       assert args["baz"] == "bong"
       assert args["bar"] == "zing"
       assert (args |> Map.keys |> length) == 3

--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -23,6 +23,17 @@ defmodule HTTPoisonTest do
     end
   end
 
+  test "get with params in url and options" do
+    resp = HTTPoison.get("localhost:8080/get?bar=zing&foo=overridden", [], params: %{foo: "bar", baz: "bong"})
+    assert_response resp, fn(response) ->
+      args = JSX.decode!(response.body)["args"]
+      assert args["foo"] == "bar"
+      assert args["baz"] == "bong"
+      assert args["bar"] == "zing"
+      assert (args |> Map.keys |> length) == 3
+    end
+  end
+
   test "head" do
     assert_response HTTPoison.head("localhost:8080/get"), fn(response) ->
       assert response.body == ""


### PR DESCRIPTION
before this, URLs that already contain a query string were not handled.

```
iex(3)> HTTPoison.get("https://httpbin.org/get?yolo=bolo", [], params: %{whut: "hello"})
{:ok,
 %HTTPoison.Response{body: "{\n  \"args\": {\n    \"yolo\": \"bolo?whut=hello\"\n  }, \n  \"headers\": {\n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"hackney/1.6.5\"\n  }, \n  \"origin\": \"193.240.195.178\", \n  \"url\": \"https://httpbin.org/get?yolo=bolo%3Fwhut=hello\"\n}\n",
  headers: [{"Server", "nginx"}, {"Date", "Thu, 16 Feb 2017 10:29:15 GMT"},
   {"Content-Type", "application/json"}, {"Content-Length", "225"},
   {"Connection", "keep-alive"}, {"Access-Control-Allow-Origin", "*"},
   {"Access-Control-Allow-Credentials", "true"}], status_code: 200}}
```

note that the URL used was `https://httpbin.org/get?yolo=bolo%3Fwhut=hello` not `https://httpbin.org/get?yolo=bolo&whut=hello`