### PR TITLE
Show installing latest version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ First, add HTTPoison to your `mix.exs` dependencies:
 
 ```elixir
 def deps do
-  [{:httpoison, "~> 0.10.0"}]
+  [{:httpoison, "~> 0.11.1"}]
 end
 ```
 


### PR DESCRIPTION
Installing the version shown produces a warning because the hackney version it depends on is "retired".