### PR TITLE
Extend Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: elixir
 elixir:
   - 1.2.6
   - 1.3.4
+  - 1.4
 otp_release:
   - 18.3
-  - 19.2
+  - 19.3


### PR DESCRIPTION
Hi, 

A small update to test against the latest Elixir 1.4 and bump the OTP version to 19.3.

Thanks
Sam