### PR TITLE
#259 Orphan processes waiting in HTTPoison.Base.transformer/5

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -417,7 +417,7 @@ defmodule HTTPoison.Base do
           nil   -> :async
           :once -> {:async, :once}
         end
-        [async_option, {:stream_to, spawn(module, :transformer, [stream_to])} | hn_options]
+        [async_option, {:stream_to, spawn_link(module, :transformer, [stream_to])} | hn_options]
       else
         hn_options
       end


### PR DESCRIPTION
Use `spawn_link` instead of `spawn`