### PR TITLE
Update hackney to 1.8.6

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule HTTPoison.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 1.8.0"},
+      {:hackney, "~> 1.8.6"},
       {:exjsx, "~> 3.1", only: :test},
       {:httparrot, "~> 0.5", only: :test},
       {:meck, "~> 0.8.2", only: :test},


### PR DESCRIPTION
Hi. I'm using dialyzer it depends httpoison.
I found error when getting error building a plt of certifi, 
And It caused by an old version of hackney depends on an  old version of certifi.

## Summery
- Updated hackney of latest version.

## Backgrounds
- current version of hackney has dialyzer warnings. (https://github.com/benoitc/hackney/issues/409)
- now latest version of hackney, solved dialyzer bugs.