### PR TITLE
loosen hackney version constraint

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule HTTPoison.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 1.8.0"},
+      {:hackney, "~> 1.8"},
       {:exjsx, "~> 3.1", only: :test},
       {:httparrot, "~> 0.5", only: :test},
       {:meck, "~> 0.8.2", only: :test},


### PR DESCRIPTION
Hackney 1.9.0 is out. Changing to `1.8` instead of `1.8.0` allows people to update if they want/need to (like me 😄).