### PR TITLE
Fix headers typespec

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -76,7 +76,7 @@ defmodule HTTPoison.Base do
   alias HTTPoison.AsyncResponse
   alias HTTPoison.Error
 
-  @type headers :: [{binary, binary}] | %{binary => binary}
+  @type headers :: [{atom, binary}] | [{binary, binary}] | %{binary => binary}
   @type body :: binary | {:form, [{atom, any}]} | {:file, binary}
 
   defmacro __using__(_) do


### PR DESCRIPTION
This PR updates the typespec for `headers` to allow for `[{atom, binary}]`, since the syntax `"Content-Type": "application/json"` is valid. This was causing an error in a project I'm working on.

Update: Changed spec to `[{atom, binary}]` instead of `keyword(binary)` since Elixir 1.2 doesn't support `keyword`.