### PR TITLE
typespec allows for async response from request functions

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -185,7 +185,7 @@ defmodule HTTPoison.Base do
       response in case of a successful request, raising an exception in case the
       request fails.
       """
-      @spec request!(atom, binary, any, headers, Keyword.t) :: Response.t
+      @spec request!(atom, binary, any, headers, Keyword.t) :: Response.t | AsyncResponse.t
       def request!(method, url, body \\ "", headers \\ [], options \\ []) do
         case request(method, url, body, headers, options) do
           {:ok, response} -> response
@@ -432,7 +432,7 @@ defmodule HTTPoison.Base do
   end
 
   @doc false
-  @spec request(atom, atom, binary, body, headers, any, fun, fun, fun) :: {:ok, Response.t} | {:error, Error.t}
+  @spec request(atom, atom, binary, body, headers, any, fun, fun, fun) :: {:ok, Response.t | AsyncResponse.t} | {:error, Error.t}
   def request(module, method, request_url, request_body, request_headers, options, process_status_code, process_headers, process_response_body) do
     hn_options = build_hackney_options(module, options)
 


### PR DESCRIPTION
currently this fails dialyzer checks:

```elixir
def get do
  HTTPoison.get!(url, [], stream_to: self())
  |> read_response()
end

def read_response(%HTTPoison.AsyncResponse{}) do
end
```

dialyzer output:

```
The call 'Elixir.CoolModule':do_response(#{'__struct__':='Elixir.HTTPoison.Response', 'body':=_, 'headers':=[any()], 'request_url':=binary() |
 [binary() | maybe_improper_list(any(),binary() | []) | char()] | {'hackney_url',atom(),atom(),binary(),'undefined' | binary(),'nil' | 'undefined' | binary(),binary(),binary(),[any(
)],'undefined' | integer(),binary(),binary()}, 'status_code':=integer()}) will never return since it differs in the 1st argument from the success typing arguments: (#{'__struct__':=
'Elixir.HTTPoison.AsyncResponse', 'id':=_, _=>_})
```
and
```
The pattern #{'id':=_id@1, '__struct__':='Elixir.HTTPoison.AsyncResponse'} can never match the type #{'__struct__':='Elixir.HTTPoison.Response', 'body':
=_, 'headers':=[any()], 'request_url':=binary() | [binary() | maybe_improper_list(any(),binary() | []) | char()] | {'hackney_url',atom(),atom(),binary(),'undefined' | binary(),'nil'
 | 'undefined' | binary(),binary(),binary(),[any()],'undefined' | integer(),binary(),binary()}, 'status_code':=integer()}
```

Thanks for the great work!