### PR TITLE
Add check for HTTP_PROXY env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ erl_crash.dump
 mix.lock
 /.idea
 *.iml
+/.elixir_ls

--- a/test/httpoison_base_test.exs
+++ b/test/httpoison_base_test.exs
@@ -146,6 +146,70 @@ defmodule HTTPoisonBaseTest do
     assert validate :hackney
   end
 
+  test "having http_proxy env variable set on http requests" do
+    expect(System, :get_env, [{["HTTP_PROXY"], "proxy"}])
+
+    expect(:hackney, :request, [
+      {[:post, "http://localhost", [], "body", [proxy: "proxy"]], {:ok, 200, "headers", :client}}
+    ])
+
+    expect(:hackney, :body, 1, {:ok, "response"})
+
+    assert HTTPoison.post!("localhost", "body") ==
+             %HTTPoison.Response{
+               status_code: 200,
+               headers: "headers",
+               body: "response",
+               request_url: "http://localhost"
+             }
+
+    assert validate(:hackney)
+  end
+
+  test "having https_proxy env variable set on https requests" do
+    expect(System, :get_env, [{["HTTPS_PROXY"], "proxy"}])
+
+    expect(:hackney, :request, [
+      {[:post, "https://localhost", [], "body", [proxy: "proxy"]], {:ok, 200, "headers", :client}}
+    ])
+
+    expect(:hackney, :body, 1, {:ok, "response"})
+
+    assert HTTPoison.post!("https://localhost", "body") ==
+             %HTTPoison.Response{
+               status_code: 200,
+               headers: "headers",
+               body: "response",
+               request_url: "https://localhost"
+             }
+
+    assert validate(:hackney)
+  end
+
+  test "having https_proxy env variable set on http requests" do
+    expect(System, :get_env, [
+      {["HTTPS_PROXY"], "proxy"},
+      {["HTTP_PROXY"], nil},
+      {["http_proxy"], nil}
+    ])
+
+    expect(:hackney, :request, [
+      {[:post, "http://localhost", [], "body", []], {:ok, 200, "headers", :client}}
+    ])
+
+    expect(:hackney, :body, 1, {:ok, "response"})
+
+    assert HTTPoison.post!("localhost", "body") ==
+             %HTTPoison.Response{
+               status_code: 200,
+               headers: "headers",
+               body: "response",
+               request_url: "http://localhost"
+             }
+
+    assert validate(:hackney)
+  end
+
   test "passing ssl option" do
     expect(:hackney, :request, [{[:post, "http://localhost", [], "body", [ssl_options: [certfile: "certs/client.crt"]]],
                                  {:ok, 200, "headers", :client}}])


### PR DESCRIPTION
If no proxy option is passed, this will check if a env var for proxies is set.
If none is set everything will operate as usual.

Fixes #305