### PR TITLE
Bumped up hackney version to 1.11.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule HTTPoison.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 1.8"},
+      {:hackney, "~> 1.11.0"},
       {:exjsx, "~> 3.1", only: :test},
       {:httparrot, "~> 1.0", only: :test},
       {:meck, "~> 0.8.2", only: :test},


### PR DESCRIPTION
Hi,

Today I ran into this issue https://github.com/benoitc/hackney/issues/420 and noticed that you use an old version of hackney (1.8.6)

So, I offer you to bump it up.