### PR TITLE
add support for socks5 user and pass parameters.

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -440,11 +440,19 @@ defmodule HTTPoison.Base do
       end
 
     proxy_auth = Keyword.get(options, :proxy_auth)
+    socks5_user = Keyword.get(options, :socks5_user)
+    socks5_pass = Keyword.get(options, :socks5_pass)
 
     hn_proxy_options = if proxy, do: [{:proxy, proxy}], else: []
 
     hn_proxy_options =
       if proxy_auth, do: [{:proxy_auth, proxy_auth} | hn_proxy_options], else: hn_proxy_options
+
+    hn_proxy_options =
+      if socks5_user, do: [{:socks5_user, socks5_user} | hn_proxy_options], else: hn_proxy_options
+
+    hn_proxy_options =
+      if socks5_pass, do: [{:socks5_pass, socks5_pass} | hn_proxy_options], else: hn_proxy_options
 
     hn_proxy_options
   end

--- a/test/httpoison_base_test.exs
+++ b/test/httpoison_base_test.exs
@@ -137,12 +137,12 @@ defmodule HTTPoisonBaseTest do
       [:post, "http://localhost", [], "body",  [
           socks5_pass: "secret",
           socks5_user: "user",
-          proxy: {:socks5, 'http://localhost', 1080}
+          proxy: {:socks5, 'localhost', 1080}
         ]],
       {:ok, 200, "headers", :client}}])
     expect(:hackney, :body, 1, {:ok, "response"})
 
-    assert HTTPoison.post!("localhost", "body", [], proxy: {:socks5, 'http://localhost', 1080}, socks5_user: "user", socks5_pass: "secret") ==
+    assert HTTPoison.post!("localhost", "body", [], proxy: {:socks5, 'localhost', 1080}, socks5_user: "user", socks5_pass: "secret") ==
     %HTTPoison.Response{ status_code: 200,
                          headers: "headers",
                          body: "response",

--- a/test/httpoison_base_test.exs
+++ b/test/httpoison_base_test.exs
@@ -132,6 +132,25 @@ defmodule HTTPoisonBaseTest do
     assert validate :hackney
   end
 
+  test "passing socks5 options" do
+    expect(:hackney, :request, [{
+      [:post, "http://localhost", [], "body",  [
+          socks5_pass: "secret",
+          socks5_user: "user",
+          proxy: {:socks5, 'http://localhost', 1080}
+        ]],
+      {:ok, 200, "headers", :client}}])
+    expect(:hackney, :body, 1, {:ok, "response"})
+
+    assert HTTPoison.post!("localhost", "body", [], proxy: {:socks5, 'http://localhost', 1080}, socks5_user: "user", socks5_pass: "secret") ==
+    %HTTPoison.Response{ status_code: 200,
+                         headers: "headers",
+                         body: "response",
+                         request_url: "http://localhost" }
+
+    assert validate :hackney
+  end
+
   test "passing proxy option with proxy_auth" do
     expect(:hackney, :request, [{[:post, "http://localhost", [], "body", [proxy_auth: {"username", "password"}, proxy: "proxy"]],
                                  {:ok, 200, "headers", :client}}])


### PR DESCRIPTION
Hackney supports the connection via a socks5 proxy. To set a socks5 proxy, it uses the following settings:

* {proxy, {socks5, ProxyHost, ProxyPort}}: to set the host and port of the proxy to connect.
* {socks5_user, Username}: to set the user used to connect to the proxy
* {socks5_pass, Password}: to set the password used to connect to the proxy

This info from hackney documentation.

This PR adding support of socks5_user and socks5_pass.