### PR TITLE
HTTPoison.Base behaviour

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -76,11 +76,111 @@ defmodule HTTPoison.Base do
   alias HTTPoison.AsyncResponse
   alias HTTPoison.Error
 
+  @callback delete(url) :: {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+  @callback delete(url, headers) :: {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+  @callback delete(url, headers, options) ::
+              {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+
+  @callback delete!(url) :: Response.t() | AsyncResponse.t()
+  @callback delete!(url, headers) :: Response.t() | AsyncResponse.t()
+  @callback delete!(url, headers, options) :: Response.t() | AsyncResponse.t()
+
+  @callback get(url) :: {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+  @callback get(url, headers) :: {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+  @callback get(url, headers, options) ::
+              {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+
+  @callback get!(url) :: Response.t() | AsyncResponse.t()
+  @callback get!(url, headers) :: Response.t() | AsyncResponse.t()
+  @callback get!(url, headers, options) :: Response.t() | AsyncResponse.t()
+
+  @callback head(url) :: {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+  @callback head(url, headers) :: {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+  @callback head(url, headers, options) ::
+              {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+
+  @callback head!(url) :: Response.t() | AsyncResponse.t()
+  @callback head!(url, headers) :: Response.t() | AsyncResponse.t()
+  @callback head!(url, headers, options) :: Response.t() | AsyncResponse.t()
+
+  @callback options(url) :: {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+  @callback options(url, headers) :: {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+  @callback options(url, headers, options) ::
+              {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+
+  @callback options!(url) :: Response.t() | AsyncResponse.t()
+  @callback options!(url, headers) :: Response.t() | AsyncResponse.t()
+  @callback options!(url, headers, options) :: Response.t() | AsyncResponse.t()
+
+  @callback patch(url, term) :: {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+  @callback patch(url, term, headers) ::
+              {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+  @callback patch(url, term, headers, options) ::
+              {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+
+  @callback patch!(url, term) :: Response.t() | AsyncResponse.t()
+  @callback patch!(url, term, headers) :: Response.t() | AsyncResponse.t()
+  @callback patch!(url, term, headers, options) :: Response.t() | AsyncResponse.t()
+
+  @callback post(url, term) :: {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+  @callback post(url, term, headers) ::
+              {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+  @callback post(url, term, headers, options) ::
+              {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+
+  @callback post!(url, term) :: Response.t() | AsyncResponse.t()
+  @callback post!(url, term, headers) :: Response.t() | AsyncResponse.t()
+  @callback post!(url, term, headers, options) :: Response.t() | AsyncResponse.t()
+
+  @callback process_headers(headers) :: headers
+
+  @callback process_request_body(term) :: body
+
+  @callback process_request_headers(headers) :: headers
+
+  @callback process_request_options(options) :: options
+
+  @callback process_response_body(binary) :: term
+
+  @callback process_response_chunk(binary) :: term
+
+  @callback process_status_code(integer) :: term
+
+  @callback process_url(binary) :: binary
+
+  @callback put(binary) :: {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+  @callback put(binary, term) :: {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+  @callback put(binary, term, headers) ::
+              {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+  @callback put(binary, term, headers, options) ::
+              {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+
+  @callback put!(binary) :: Response.t() | AsyncResponse.t()
+  @callback put!(binary, term) :: Response.t() | AsyncResponse.t()
+  @callback put!(binary, term, headers) :: Response.t() | AsyncResponse.t()
+  @callback put!(binary, term, headers, options) :: Response.t() | AsyncResponse.t()
+
+  @callback request(atom, binary, term) :: {:ok, Response.t() | AsyncResponse.t()}
+  @callback request(atom, binary, term, headers) :: {:ok, Response.t() | AsyncResponse.t()}
+  @callback request(atom, binary, term, headers, options) ::
+              {:ok, Response.t() | AsyncResponse.t()}
+
+  @callback request!(atom, binary) :: Response.t() | AsyncResponse.t()
+  @callback request!(atom, binary, term) :: Response.t() | AsyncResponse.t()
+  @callback request!(atom, binary, term, headers) :: Response.t() | AsyncResponse.t()
+
+  @callback start() :: {:ok, [atom]} | {:error, term}
+
+  @callback stream_next(AsyncResponse.t()) :: {:ok, AsyncResponse.t()} | {:error, Error.t()}
+
+  @type url :: binary
   @type headers :: [{atom, binary}] | [{binary, binary}] | %{binary => binary}
   @type body :: binary | {:form, [{atom, any}]} | {:file, binary}
+  @type options :: Keyword.t()
 
   defmacro __using__(_) do
     quote do
+      @behaviour HTTPoison.Base
       @type headers :: HTTPoison.Base.headers
       @type body :: HTTPoison.Base.body
 

--- a/test/httpoison_base_test.exs
+++ b/test/httpoison_base_test.exs
@@ -13,17 +13,6 @@ defmodule HTTPoisonBaseTest do
     def process_status_code(code), do: {:code, code}
   end
 
-  defmodule ExampleDefp do
-    use HTTPoison.Base
-    defp process_url(url), do: "http://" <> url
-    defp process_request_body(body), do: {:req_body, body}
-    defp process_request_headers(headers), do: {:req_headers, headers}
-    defp process_request_options(options), do: Keyword.put(options, :timeout, 10)
-    defp process_response_body(body), do: {:resp_body, body}
-    defp process_headers(headers), do: {:headers, headers}
-    defp process_status_code(code), do: {:code, code}
-  end
-
   defmodule ExampleParamsOptions do
     use HTTPoison.Base
     def process_url(url), do: "http://" <> url
@@ -42,20 +31,6 @@ defmodule HTTPoisonBaseTest do
     expect(:hackney, :body, 1, {:ok, "response"})
 
     assert Example.post!("localhost", "body") ==
-    %HTTPoison.Response{ status_code: {:code, 200},
-                         headers: {:headers, "headers"},
-                         body: {:resp_body, "response"},
-                         request_url: "http://localhost" }
-
-    assert validate :hackney
-  end
-
-  test "request body using ExampleDefp" do
-    expect(:hackney, :request, [{[:post, "http://localhost", {:req_headers, []}, {:req_body, "body"}, [{:connect_timeout, 10}]],
-                                 {:ok, 200, "headers", :client}}])
-    expect(:hackney, :body, 1, {:ok, "response"})
-
-    assert ExampleDefp.post!("localhost", "body") ==
     %HTTPoison.Response{ status_code: {:code, 200},
                          headers: {:headers, "headers"},
                          body: {:resp_body, "response"},


### PR DESCRIPTION
This makes HTTPoison.Base a behaviour module.

This has the following benefits:
* Functions in the callback module that uses HTTPoison.Base can be marked with `@impl`
* It can now be used directly with Mox without a wrapping module.

This will cause warnings if the callback module using HTTPoison.Base overrides functions that are public with private ones.