### PR TITLE
Update HTTP.Base request callback typespec to include error tuple

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -160,10 +160,12 @@ defmodule HTTPoison.Base do
   @callback put!(binary, term, headers) :: Response.t() | AsyncResponse.t()
   @callback put!(binary, term, headers, options) :: Response.t() | AsyncResponse.t()
 
-  @callback request(atom, binary, term) :: {:ok, Response.t() | AsyncResponse.t()}
-  @callback request(atom, binary, term, headers) :: {:ok, Response.t() | AsyncResponse.t()}
+  @callback request(atom, binary, term) ::
+              {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
+  @callback request(atom, binary, term, headers) ::
+              {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
   @callback request(atom, binary, term, headers, options) ::
-              {:ok, Response.t() | AsyncResponse.t()}
+              {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
 
   @callback request!(atom, binary) :: Response.t() | AsyncResponse.t()
   @callback request!(atom, binary, term) :: Response.t() | AsyncResponse.t()


### PR DESCRIPTION
The `HTTPoison.Base.request/5` function can return an `{:error, ...}` tuple, which is not represented in the callback typespec/signature.  This results the following dialyzer warning:

> lib/httpoison.ex:66: The return type {'error',#{'__exception__':=_, '__struct__':='Elixir.HTTPoison.Error', 'id':='nil' | reference(), 'reason':=_}} in the specification of request/5 is not a subtype of {'ok',#{'__struct__':='Elixir.HTTPoison.AsyncResponse' | 'Elixir.HTTPoison.Response', 'body'=>_, 'headers'=>[any()], 'id'=>reference(), 'request_url'=>_, 'status_code'=>integer()}}, which is the expected return type for the callback of the 'Elixir.HTTPoison.Base' behaviour

The warning also bleeds into any project that uses `use HTTPoison.Base`.
