### PR TITLE
warn about this stream_to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,11 @@ iex> flush
 :ok
 ```
 
+**Warning: this option can flood a receiver in messages.**
+
+If a server may send very large messages the `async: :once` option should be used.
+This will send only a single chunk at a time the receiver can call `HTTPoison.stream_next/1` to indicate ability to process more chunks. 
+
 ### Cookies
 
 HTTPoison allows you to send cookies:


### PR DESCRIPTION
As mentioned by Jose in this topic https://elixirforum.com/t/streaming-http-response-without-running-out-of-memory/1887/3, stream_to is a dangerous API