### PR TITLE
Document Difference Between the Two Time-Out Options

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -248,8 +248,8 @@ defmodule HTTPoison.Base do
         * `{:stream, enumerable}` - lazily send a stream of binaries/charlists
 
       Options:
-        * `:timeout` - timeout to establish a connection, in milliseconds. Default is 8000
-        * `:recv_timeout` - timeout used when receiving a connection. Default is 5000
+        * `:timeout` - timeout for establishing a TCP or SSL connection, in milliseconds. Default is 8000
+        * `:recv_timeout` - timeout for receiving an HTTP response from the socket. Default is 5000
         * `:stream_to` - a PID to stream the response to
         * `:async` - if given `:once`, will only stream one message at a time, requires call to `stream_next`
         * `:proxy` - a proxy to be used for the request; it can be a regular url


### PR DESCRIPTION
This should resolve https://github.com/edgurgel/httpoison/issues/299

Some resources to save digging around:

- https://github.com/benoitc/hackney/blob/1.8.6/src/hackney_response.erl#L336
- https://github.com/benoitc/hackney/blob/1.8.6/src/hackney_connect.erl
- http://erlang.org/doc/man/gen_tcp.html#connect-4
- http://erlang.org/doc/man/ssl.html#connect-4