### PR TITLE
add option :max_body_length for :hackney.body/2

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -261,6 +261,7 @@ defmodule HTTPoison.Base do
         * `:follow_redirect` - a boolean that causes redirects to be followed
         * `:max_redirect` - an integer denoting the maximum number of redirects to follow
         * `:params` - an enumerable consisting of two-item tuples that will be appended to the url as query string parameters
+        * `:max_body_length` - a non-negative integer denoting the max response body length. Errors when body length exceeds. See :hackney.body/2
 
       Timeouts can be an integer or `:infinity`
 
@@ -642,7 +643,9 @@ defmodule HTTPoison.Base do
         )
 
       {:ok, status_code, headers, client} ->
-        case :hackney.body(client) do
+        max_length = Keyword.get(options, :max_body_length, :infinity)
+
+        case :hackney.body(client, max_length) do
           {:ok, body} ->
             response(
               process_status_code,

--- a/test/httpoison_base_test.exs
+++ b/test/httpoison_base_test.exs
@@ -41,7 +41,7 @@ defmodule HTTPoisonBaseTest do
         {:ok, 200, "headers", :client}
     end)
 
-    expect(:hackney, :body, fn _ -> {:ok, "response"} end)
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
 
     assert Example.post!("localhost", "body") ==
              %HTTPoison.Response{
@@ -57,7 +57,7 @@ defmodule HTTPoisonBaseTest do
       {:ok, 200, "headers", :client}
     end)
 
-    expect(:hackney, :body, fn _ -> {:ok, "response"} end)
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
 
     assert ExampleParamsOptions.get!("localhost", [], params: %{foo: "bar"}) ==
              %HTTPoison.Response{
@@ -87,7 +87,7 @@ defmodule HTTPoisonBaseTest do
         {:ok, 200, "headers", :client}
     end)
 
-    expect(:hackney, :body, fn _ -> {:ok, "response"} end)
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
 
     assert HTTPoison.post!("localhost", "body", [], timeout: 12345) ==
              %HTTPoison.Response{
@@ -104,7 +104,7 @@ defmodule HTTPoisonBaseTest do
         {:ok, 200, "headers", :client}
     end)
 
-    expect(:hackney, :body, fn _ -> {:ok, "response"} end)
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
 
     assert HTTPoison.post!("localhost", "body", [], recv_timeout: 12345) ==
              %HTTPoison.Response{
@@ -120,7 +120,7 @@ defmodule HTTPoisonBaseTest do
       :post, "http://localhost", [], "body", [proxy: "proxy"] -> {:ok, 200, "headers", :client}
     end)
 
-    expect(:hackney, :body, fn _ -> {:ok, "response"} end)
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
 
     assert HTTPoison.post!("localhost", "body", [], proxy: "proxy") ==
              %HTTPoison.Response{
@@ -145,7 +145,7 @@ defmodule HTTPoisonBaseTest do
         {:ok, 200, "headers", :client}
     end)
 
-    expect(:hackney, :body, fn _ -> {:ok, "response"} end)
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
 
     assert HTTPoison.post!(
              "localhost",
@@ -173,7 +173,7 @@ defmodule HTTPoisonBaseTest do
         {:ok, 200, "headers", :client}
     end)
 
-    expect(:hackney, :body, fn _ -> {:ok, "response"} end)
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
 
     assert HTTPoison.post!(
              "localhost",
@@ -197,7 +197,7 @@ defmodule HTTPoisonBaseTest do
       :post, "http://localhost", [], "body", [proxy: "proxy"] -> {:ok, 200, "headers", :client}
     end)
 
-    expect(:hackney, :body, fn _ -> {:ok, "response"} end)
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
 
     assert HTTPoison.post!("localhost", "body") ==
              %HTTPoison.Response{
@@ -215,7 +215,7 @@ defmodule HTTPoisonBaseTest do
       {:ok, 200, "headers", :client}
     end)
 
-    expect(:hackney, :body, fn _ -> {:ok, "response"} end)
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
 
     assert HTTPoison.post!("localhost", "body") ==
              %HTTPoison.Response{
@@ -233,7 +233,7 @@ defmodule HTTPoisonBaseTest do
       {:ok, 200, "headers", :client}
     end)
 
-    expect(:hackney, :body, fn _ -> {:ok, "response"} end)
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
 
     assert HTTPoison.post!("https://localhost", "body") ==
              %HTTPoison.Response{
@@ -251,7 +251,7 @@ defmodule HTTPoisonBaseTest do
       :post, "http://localhost", [], "body", [] -> {:ok, 200, "headers", :client}
     end)
 
-    expect(:hackney, :body, fn _ -> {:ok, "response"} end)
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
 
     assert HTTPoison.post!("localhost", "body") ==
              %HTTPoison.Response{
@@ -271,7 +271,7 @@ defmodule HTTPoisonBaseTest do
       {:ok, 200, "headers", :client}
     end)
 
-    expect(:hackney, :body, fn _ -> {:ok, "response"} end)
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
 
     assert HTTPoison.post!("localhost", "body", [], ssl: [certfile: "certs/client.crt"]) ==
              %HTTPoison.Response{
@@ -291,7 +291,7 @@ defmodule HTTPoisonBaseTest do
       {:ok, 200, "headers", :client}
     end)
 
-    expect(:hackney, :body, fn _ -> {:ok, "response"} end)
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
 
     assert HTTPoison.post!("localhost", "body", [], follow_redirect: true) ==
              %HTTPoison.Response{
@@ -307,7 +307,7 @@ defmodule HTTPoisonBaseTest do
       {:ok, 200, "headers", :client}
     end)
 
-    expect(:hackney, :body, fn _ -> {:ok, "response"} end)
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
 
     assert HTTPoison.post!("localhost", "body", [], max_redirect: 2) ==
              %HTTPoison.Response{
@@ -316,5 +316,31 @@ defmodule HTTPoisonBaseTest do
                body: "response",
                request_url: "http://localhost"
              }
+  end
+
+  test "passing max_body_length option" do
+    expect(:hackney, :request, fn :get, "http://localhost", [], "", [] ->
+      {:ok, 200, "headers", :client}
+    end)
+
+    expect(:hackney, :body, fn _, :infinity -> {:ok, "response"} end)
+
+    assert HTTPoison.get("localhost") ==
+             {:ok,
+              %HTTPoison.Response{
+                status_code: 200,
+                headers: "headers",
+                body: "response",
+                request_url: "http://localhost"
+              }}
+
+    expect(:hackney, :request, fn :get, "http://localhost", [], "", [] ->
+      {:ok, 200, "headers", :client}
+    end)
+
+    expect(:hackney, :body, fn _, _ -> {:error, "some error"} end)
+
+    assert HTTPoison.get("localhost", [], max_body_length: 3) ==
+             {:error, %HTTPoison.Error{id: nil, reason: "some error"}}
   end
 end


### PR DESCRIPTION
Add option allowing for `:max_body_length` to be passed to `:hackney.body/2`.

This should enable one to limit outgoing requests the same way you can limit incoming requests with `Plug.parsers`'s `:length` option