### PR TITLE
correct :max_body_length documentation and spec

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -261,7 +261,7 @@ defmodule HTTPoison.Base do
         * `:follow_redirect` - a boolean that causes redirects to be followed
         * `:max_redirect` - an integer denoting the maximum number of redirects to follow
         * `:params` - an enumerable consisting of two-item tuples that will be appended to the url as query string parameters
-        * `:max_body_length` - a non-negative integer denoting the max response body length. Errors when body length exceeds. See :hackney.body/2
+        * `:max_body_length` - a non-negative integer denoting the max response body length. See :hackney.body/2
 
       Timeouts can be an integer or `:infinity`
 

--- a/test/httpoison_base_test.exs
+++ b/test/httpoison_base_test.exs
@@ -338,9 +338,15 @@ defmodule HTTPoisonBaseTest do
       {:ok, 200, "headers", :client}
     end)
 
-    expect(:hackney, :body, fn _, _ -> {:error, "some error"} end)
+    expect(:hackney, :body, fn _, _ -> {:ok, "res"} end)
 
     assert HTTPoison.get("localhost", [], max_body_length: 3) ==
-             {:error, %HTTPoison.Error{id: nil, reason: "some error"}}
+             {:ok,
+              %HTTPoison.Response{
+                status_code: 200,
+                headers: "headers",
+                body: "res",
+                request_url: "http://localhost"
+              }}
   end
 end


### PR DESCRIPTION
I'm sorry, but it seems #354's assumed behaviour was wrong.
I assumed the `:max_length` in `body/2` would error, because, what would an incomplete response be worth, but it seems it simply returns the body up until `:max_length`.

I have corrected the doc and spec to reflect this.
I will submit another PR implementing this behaviour in HTTPoison, since my original intention was to protect against too much data being returned with an error.

Sorry for the mistake @edgurgel 