### PR TITLE
Added support for the NO_PROXY env variable

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -622,9 +622,10 @@ defmodule HTTPoison.Base do
   defp check_no_proxy(proxy, request_url) do
     request_host = URI.parse(request_url).host
 
-    should_bypass_proxy = get_no_proxy_system_env()
-        |> String.split(",")
-        |> Enum.any?(fn domain -> matches_no_proxy_value?(request_host, domain) end)
+    should_bypass_proxy =
+      get_no_proxy_system_env()
+      |> String.split(",")
+      |> Enum.any?(fn domain -> matches_no_proxy_value?(request_host, domain) end)
 
     if should_bypass_proxy do
       nil
@@ -634,8 +635,7 @@ defmodule HTTPoison.Base do
   end
 
   defp get_no_proxy_system_env() do
-    System.get_env("NO_PROXY") || System.get_env("no_PROXY") || System.get_env("no_proxy") ||
-        ""
+    System.get_env("NO_PROXY") || System.get_env("no_PROXY") || System.get_env("no_proxy") || ""
   end
 
   defp matches_no_proxy_value?(request_host, no_proxy_value) do

--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -593,6 +593,7 @@ defmodule HTTPoison.Base do
           "https" -> System.get_env("HTTPS_PROXY") || System.get_env("https_proxy")
           _ -> nil
         end
+        |> check_no_proxy(request_url)
       end
 
     proxy_auth = Keyword.get(options, :proxy_auth)
@@ -611,6 +612,46 @@ defmodule HTTPoison.Base do
       if socks5_pass, do: [{:socks5_pass, socks5_pass} | hn_proxy_options], else: hn_proxy_options
 
     hn_proxy_options
+  end
+
+  defp check_no_proxy(nil, _) do
+    # Don't bother to check no_proxy if there's no proxy to use anyway.
+    nil
+  end
+
+  defp check_no_proxy(proxy, request_url) do
+    request_host = URI.parse(request_url).host
+
+    should_bypass_proxy = get_no_proxy_system_env()
+        |> String.split(",")
+        |> Enum.any?(fn domain -> matches_no_proxy_value?(request_host, domain) end)
+
+    if should_bypass_proxy do
+      nil
+    else
+      proxy
+    end
+  end
+
+  defp get_no_proxy_system_env() do
+    System.get_env("NO_PROXY") || System.get_env("no_PROXY") || System.get_env("no_proxy") ||
+        ""
+  end
+
+  defp matches_no_proxy_value?(request_host, no_proxy_value) do
+    cond do
+      no_proxy_value == "" -> false
+      String.starts_with?(no_proxy_value, ".") -> String.ends_with?(request_host, no_proxy_value)
+      String.contains?(no_proxy_value, "*") -> matches_wildcard?(request_host, no_proxy_value)
+      true -> request_host == no_proxy_value
+    end
+  end
+
+  defp matches_wildcard?(request_host, wildcard_domain) do
+    Regex.escape(wildcard_domain)
+    |> String.replace("\\*", ".*")
+    |> Regex.compile!()
+    |> Regex.match?(request_host)
   end
 
   @doc false

--- a/test/httpoison_base_test.exs
+++ b/test/httpoison_base_test.exs
@@ -120,7 +120,7 @@ defmodule HTTPoisonBaseTest do
 
   test "passing proxy option" do
     expect_hackney_post_with_proxy("http://localhost", "proxy")
-    
+
     assert HTTPoison.post!("localhost", "body", [], proxy: "proxy") ==
              %HTTPoison.Response{
                status_code: 200,
@@ -337,7 +337,7 @@ defmodule HTTPoisonBaseTest do
   end
 
   defp expect_hackney_post_with_proxy(url, proxy) do
-    expect_hackney_post(url, [proxy: proxy])
+    expect_hackney_post(url, proxy: proxy)
   end
 
   defp expect_hackney_post_with_no_proxy(url) do


### PR DESCRIPTION
This commit adds support for the NO_PROXY (or no_PROXY / no_proxy) environment variable in a [GNU-supported format](https://www.gnu.org/software/emacs/manual/html_node/url/Proxies.html) to fix #331.