### PR TITLE
added support for no_proxy env_var

### DIFF
--- a/test/httpoison_base_test.exs
+++ b/test/httpoison_base_test.exs
@@ -29,6 +29,8 @@ defmodule HTTPoisonBaseTest do
       System.delete_env("http_proxy")
       System.delete_env("HTTPS_PROXY")
       System.delete_env("https_proxy")
+      System.delete_env("no_proxy")
+      System.delete_env("NO_PROXY")
     end)
 
     stub(:hackney)
@@ -246,6 +248,25 @@ defmodule HTTPoisonBaseTest do
 
   test "having https_proxy env variable set on http requests" do
     System.put_env("HTTPS_PROXY", "proxy")
+
+    expect(:hackney, :request, fn
+      :post, "http://localhost", [], "body", [] -> {:ok, 200, "headers", :client}
+    end)
+
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
+
+    assert HTTPoison.post!("localhost", "body") ==
+             %HTTPoison.Response{
+               status_code: 200,
+               headers: "headers",
+               body: "response",
+               request_url: "http://localhost"
+             }
+  end
+
+  test "having no_proxy env variable set on http requests" do
+    System.put_env("HTTP_PROXY", "proxy")
+    System.put_env("no_proxy", "localhost")
 
     expect(:hackney, :request, fn
       :post, "http://localhost", [], "body", [] -> {:ok, 200, "headers", :client}


### PR DESCRIPTION
Hello,  
I'm not sure what your position is regarding unsolicited contributions, but I was struggling with my corporate firewall policies so I added some basic support for the 'no_proxy' environmental variable.

I'm happy to make additional changes but it's also totally fine if you don't want to accept this pull request if you don't agree with this change or the general way it was implemented.

