### PR TITLE
Update version number in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ First, add HTTPoison to your `mix.exs` dependencies:
 
 ```elixir
 def deps do
-  [{:httpoison, "~> 1.0"}]
+  [{:httpoison, "~> 1.4"}]
 end
 ```
 


### PR DESCRIPTION
Some documentation later on in the README is specific to version 1.4+ (see 94ab53452b1d290f26c6e541e22c293992bb1790)

I couldn't figure out why my `process_request_url` wasn't being called.  As far as I can tell, I only had v1.3.1 cached locally (from a different project), so `~> 1.0` gave me that, instead of the latest & greatest.  

Figured this change might help save other people from the same confusion