### PR TITLE
Remove @type response in ref to tentacat/issues/152

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -203,7 +203,6 @@ defmodule HTTPoison.Base do
     quote do
       @behaviour HTTPoison.Base
 
-      @type response :: HTTPoison.Base.response()
       @type request :: HTTPoison.Base.request()
       @type url :: HTTPoison.Base.url()
       @type headers :: HTTPoison.Base.headers()
@@ -241,7 +240,7 @@ defmodule HTTPoison.Base do
       @spec process_request_params(params) :: params
       def process_request_params(params), do: params
 
-      @spec process_response(response) :: any
+      @spec process_response(HTTPoison.Base.response()) :: any
       def process_response(%Response{} = response), do: response
 
       @deprecated "Use process_response_headers/1 instead"


### PR DESCRIPTION
I contribute to a project using HTTPoison 1.5.0 and we'd like to use Tentacat as well.

I did this work assuming it follows the suggestion from @edgurgel's comment in https://github.com/edgurgel/tentacat/issues/152#issuecomment-433734726

I'm not sure if there's other work to be done in Tentacat but I'd be happy to look at that too. It doesn't look like it's using any of the methods that were deprecated in 1.4.0.