### PR TITLE
Update Hackney version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule HTTPoison.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 1.15"},
+      {:hackney, ">= 1.15.2"},
       {:mimic, "~> 0.1", only: :test},
       {:exjsx, "~> 3.1", only: :test},
       {:httparrot, "~> 1.2", only: :test},

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule HTTPoison.Mixfile do
 
   defp deps do
     [
-      {:hackney, "~> 1.8"},
+      {:hackney, "~> 1.15"},
       {:mimic, "~> 0.1", only: :test},
       {:exjsx, "~> 3.1", only: :test},
       {:httparrot, "~> 1.2", only: :test},

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule HTTPoison.Mixfile do
 
   defp deps do
     [
-      {:hackney, ">= 1.15.2"},
+      {:hackney, "~> 1.15 and >= 1.15.2"},
       {:mimic, "~> 0.1", only: :test},
       {:exjsx, "~> 3.1", only: :test},
       {:httparrot, "~> 1.2", only: :test},


### PR DESCRIPTION
Per https://github.com/benoitc/hackney/issues/591, hackney 1.15.2 fixes
the "honor_cipher_order' issue present when sending https requests on
OTP 22.1