### PR TITLE
Exit transformer on target process exit

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -576,6 +576,9 @@ defmodule HTTPoison.Base do
         process_response_headers,
         process_response_chunk
       ) do
+    # Track the target process so we can exit when it dies
+    Process.monitor(target)
+
     receive do
       {:hackney_response, id, {:status, code, _reason}} ->
         send(target, %HTTPoison.AsyncStatus{id: id, code: process_response_status_code.(code)})
@@ -622,6 +625,10 @@ defmodule HTTPoison.Base do
           process_response_headers,
           process_response_chunk
         )
+
+      # Exit if the target process dies as this will be a zombie
+      {:DOWN, _ref, :process, ^target, _reason} ->
+        :ok
     end
   end
 


### PR DESCRIPTION
When making an asynchronous response, if the target process dies (or is killed) there is no purpose in the transformer process still continuing to run, so we should kill this also.

This is a simple fix that I believe partially solves #375 .  An alternative would be to allow the target process to kill the transformer in some way by sending it a message, but I think the approach in this PR is safer.