### PR TITLE
Replace JSX with Jason

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,6 @@ defmodule HTTPoison.Mixfile do
     [
       {:hackney, "~> 1.15 and >= 1.15.2"},
       {:mimic, "~> 0.1", only: :test},
-      {:exjsx, "~> 3.1", only: :test},
       {:jason, "~> 1.2", only: :test},
       {:httparrot, "~> 1.2", only: :test},
       {:earmark, "~> 1.0", only: :dev},

--- a/mix.exs
+++ b/mix.exs
@@ -45,6 +45,7 @@ defmodule HTTPoison.Mixfile do
       {:hackney, "~> 1.15 and >= 1.15.2"},
       {:mimic, "~> 0.1", only: :test},
       {:exjsx, "~> 3.1", only: :test},
+      {:jason, "~> 1.2", only: :test},
       {:httparrot, "~> 1.2", only: :test},
       {:earmark, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.18", only: :dev},


### PR DESCRIPTION
`exjsx` is no longer maintained, this PR replaces it with `jason`. 

I've removed the `String.replace/3` calls on `httpoison_test.exs` lines `164-165` as they seem unnecessary? 