### PR TITLE
Add missing request/1 callback to behaviour

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -174,6 +174,7 @@ defmodule HTTPoison.Base do
   @callback put!(url, body, headers) :: Response.t() | AsyncResponse.t()
   @callback put!(url, body, headers, options) :: Response.t() | AsyncResponse.t()
 
+  @callback request(Request.t()) :: {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
   @callback request(method, url) :: {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}
   @callback request(method, url, body) ::
               {:ok, Response.t() | AsyncResponse.t()} | {:error, Error.t()}


### PR DESCRIPTION
We're using Mox to poison HTTPoison and we use the `request/1` function but it is missing a callback in the `HTTPoison.Base` implementation. This PR adds the missing spec.