### PR TITLE
FIX: Memory leak: HTTPoison.Base.transformer

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -286,6 +286,9 @@ defmodule HTTPoison.Base do
       @doc false
       @spec transformer(pid) :: :ok
       def transformer(target) do
+        # Track the target process so we can exit when it dies
+        Process.monitor(target)
+
         HTTPoison.Base.transformer(
           __MODULE__,
           target,
@@ -629,9 +632,6 @@ defmodule HTTPoison.Base do
         process_response_headers,
         process_response_chunk
       ) do
-    # Track the target process so we can exit when it dies
-    Process.monitor(target)
-
     receive do
       {:hackney_response, id, {:status, code, _reason}} ->
         send(target, %HTTPoison.AsyncStatus{id: id, code: process_response_status_code.(code)})


### PR DESCRIPTION
Previously `Process.monitor` had been called in every recursion
for the target even though we only need to call it only once.

I observed that on production when using httpoison to consume server sent events. Noticed in the observer_cli:

![httpoison_leak](https://user-images.githubusercontent.com/33396162/160685507-1be593d6-46ee-487e-a880-de83761c4904.jpeg)

I am currently using the PR code in production and it fixed the issue. Now also the blacked out processes to which I stream the server sent events ( so they are the target which has been monitored via Process.monitor(target) in the tranformer ) have a memory footprint of 8MB. 