### PR TITLE
Updates the `ssl` option to add settings rather than replace them

### DIFF
--- a/lib/httpoison.ex
+++ b/lib/httpoison.ex
@@ -28,7 +28,10 @@ defmodule HTTPoison.Request do
     * `:proxy_auth` - proxy authentication `{User, Password}` tuple
     * `:socks5_user`- socks5 username
     * `:socks5_pass`- socks5 password
-    * `:ssl` - SSL options supported by the `ssl` erlang module
+    * `:ssl` - SSL options supported by the `ssl` erlang module. SSL defaults will be used where options
+               are not specified.
+    * `:ssl_override` - if `:ssl` is specified, this option is ignored, otherwise it can be used to
+              completely override SSL settings.
     * `:follow_redirect` - a boolean that causes redirects to be followed, can cause a request to return
       a `MaybeRedirect` struct. See: HTTPoison.MaybeRedirect
     * `:max_redirect` - an integer denoting the maximum number of redirects to follow. Default is 5


### PR DESCRIPTION
As per issue #458, passing the `ssl` option completely overrides all settings, rather than just overwriting the "sub"-setting that was specified. Eg `ssl: [{:verions, [:'tlsv1.2']}]` disabled all TLS settings rather than just requiring TLSv1.2.

This commit changes HTTPoison's behaviour to merge the `ssl` settings with my best-guess at what the defaults are. Since it may be a breaking change, it also adds a new `ssl_override` option that can be used by anyone wishing to maintain the existing behaviour.

This resolves #458.