### PR TITLE
Conditionally process `:form` bodies to handle nested params

### DIFF
--- a/lib/httpoison.ex
+++ b/lib/httpoison.ex
@@ -134,7 +134,7 @@ defmodule HTTPoison.Request do
     headers = request.headers |> Enum.map(fn {k, v} -> "-H '#{k}: #{v}'" end) |> Enum.join(" ")
 
     body =
-      case request.body do
+      case HTTPoison.Base.maybe_process_form(request.body) do
         "" -> ""
         {:file, filename} -> "-d @#{filename}"
         {:form, form} -> form |> Enum.map(fn {k, v} -> "-F '#{k}=#{v}'" end) |> Enum.join(" ")

--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -995,6 +995,7 @@ defmodule HTTPoison.Base do
     {:form,
      Enum.flat_map(body, fn
        {k, [{_k, _v} | _rest] = v} -> flatten_nested_body(v, k)
+       {k, v} when is_map(v) -> flatten_nested_body(v, k)
        {k, v} -> [{k, v}]
      end)}
   end
@@ -1006,6 +1007,9 @@ defmodule HTTPoison.Base do
   defp flatten_nested_body(body, parent_key) do
     flattened_body =
       Enum.reduce(body, [], fn
+        {key, nested_key_values}, acc when is_map(nested_key_values) ->
+          flatten_nested_body(nested_key_values, "#{parent_key}[#{key}]") ++ acc
+
         {key, [{_key, _value} | _rest] = nested_key_values}, acc ->
           flatten_nested_body(nested_key_values, "#{parent_key}[#{key}]") ++ acc
 

--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -82,6 +82,29 @@ defmodule HTTPoisonTest do
     )
   end
 
+  test "post nested form data" do
+    assert_response(
+      HTTPoison.post(
+        "localhost:4002/post",
+        {:form, [not_nested: [1, 2], nested: [foo: "bar", again: [hello: "world"]]]},
+        %{"Content-type" => "application/x-www-form-urlencoded"}
+      ),
+      fn %HTTPoison.Response{request: request} = response ->
+        assert {:form,
+                [{:not_nested, [1, 2]}, {"nested[foo]", "bar"}, {"nested[again][hello]", "world"}]} =
+                 request.body
+
+        Regex.match?(~r/"not_nested".*\x01\x02/, response.body)
+        Regex.match?(~r/"nested\[foo\]".*"bar"/, response.body)
+        Regex.match?(~r/"nested\[again\]\[hello\]".*"world"/, response.body)
+
+        assert Request.to_curl(response.request) ==
+                 {:ok,
+                  "curl -X POST -H 'Content-type: application/x-www-form-urlencoded' -F 'not_nested=\x01\x02' -F 'nested[foo]=bar' -F 'nested[again][hello]=world' http://localhost:4002/post"}
+      end
+    )
+  end
+
   test "put" do
     assert_response(HTTPoison.put("localhost:4002/put", "test"), fn response ->
       assert Request.to_curl(response.request) ==


### PR DESCRIPTION
Ahoy again!

This PR is larger than I expected because when I was looking at the HTTPoison source when I made my issue, I didn't realise I was only looking at the `to_curl` function :disappointed:, so apologies if this is bigger than expected.

When `{:form, body}` is passed as a body into HTTPoison, we iterate over all the keys in said body and _iff_ a key contains a nested keyword-list, we apply the following transformation:

```
[something_nested: [hello: :world]] -> [{"something_nested[hello]", :world}]
```

The function added supports arbitrarily deeply nested params, and should preserve the order in which things are passed in.

~~@edgurgel do you think we should extend this to support maps as well? It should be relatively minor (a change in the pattern matches) but then we'd throw the key-ordering guarantees away. WDYT?~~
_edit: Added a second commit that adds support for maps__

Should fix https://github.com/edgurgel/httpoison/issues/469