### PR TITLE
fix code snippet(headers) of Multipart in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ can do the below:
 ```elixir
 binary_file_content = "Something you fetched and now have it in memory"
 token = "some_token_from_another_request"
-headers = ["Authorization": "Bearer #{token}", {"Content-Type", "multipart/form-data"}]
+headers = [{"Authorization", "Bearer #{token}"}, {"Content-Type", "multipart/form-data"}]
 options = [ssl: [{:versions, [:'tlsv1.2']}], recv_timeout: 500]
 
 HTTPoison.request(


### PR DESCRIPTION
Nice to meet you.
Thank you very much for the greatest http client project.

I found a bit mistake snippet in README.md .
It is `### Multipart` part.

```elixir
iex> token = "some_token_from_another_request"
iex> headers = ["Authorization": "Bearer #{token}", {"Content-Type", "multipart/form-data"}]
** (SyntaxError) iex:2:46: unexpected expression after keyword list. Keyword lists must always come last in lists and maps. Therefore, this is not allowed:

    [some: :value, :another]
    %{some: :value, another => value}

Instead, reorder it to be the last entry:

    [:another, some: :value]
    %{another => value, some: :value}

Syntax error after: ','
    |
  2 | headers = ["Authorization": "Bearer #{token}", {"Content-Type", "multipart/form-data"}]
    |                                              ^
    (iex 1.14.3) lib/iex/evaluator.ex:292: IEx.Evaluator.parse_eval_inspect/3
    (iex 1.14.3) lib/iex/evaluator.ex:187: IEx.Evaluator.loop/1
    (iex 1.14.3) lib/iex/evaluator.ex:32: IEx.Evaluator.init/4
    (stdlib 4.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```

I fixed it.

Hope this helps.