### PR TITLE
Fix formatting errors on the doc

### DIFF
--- a/lib/httpoison.ex
+++ b/lib/httpoison.ex
@@ -29,9 +29,9 @@ defmodule HTTPoison.Request do
     * `:socks5_user`- socks5 username
     * `:socks5_pass`- socks5 password
     * `:ssl` - SSL options supported by the `ssl` erlang module. SSL defaults will be used where options
-               are not specified.
+      are not specified.
     * `:ssl_override` - if `:ssl` is specified, this option is ignored, otherwise it can be used to
-              completely override SSL settings.
+      completely override SSL settings.
     * `:follow_redirect` - a boolean that causes redirects to be followed, can cause a request to return
       a `MaybeRedirect` struct. See: HTTPoison.MaybeRedirect
     * `:max_redirect` - an integer denoting the maximum number of redirects to follow. Default is 5


### PR DESCRIPTION
The number of spaces was causing a funky display on the docs:

![image](https://github.com/edgurgel/httpoison/assets/111037/2e097251-5087-4141-a9f0-f2a2defc507d)
