### PR TITLE
Better stack traces

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -219,7 +219,7 @@ defmodule HTTPoison.Base do
   @type params :: Request.params()
 
   defmacro __using__(_) do
-    quote do
+    quote location: :keep do
       @behaviour HTTPoison.Base
 
       @type request :: HTTPoison.Base.request()

--- a/mix.lock
+++ b/mix.lock
@@ -23,6 +23,6 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm", "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960"},
   "ranch": {:hex, :ranch, "1.8.0", "8c7a100a139fd57f17327b6413e4167ac559fbc04ca7448e9be9057311597a1d", [:make, :rebar3], [], "hexpm", "49fbcfd3682fab1f5d109351b61257676da1a2fdbe295904176d5e521a2ddfe5"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -19,8 +19,10 @@ defmodule HTTPoisonTest do
       assert args["baz"] == "bong"
       assert args |> Map.keys() |> length == 2
 
-      assert Request.to_curl(response.request) ==
-               {:ok, "curl -X GET http://localhost:4002/get?baz=bong&foo=bar"}
+      assert {:ok, "curl -X GET http://localhost:4002/get?" <> query} =
+               Request.to_curl(response.request)
+
+      assert %{"baz" => "bong", "foo" => "bar"} == URI.decode_query(query)
     end)
   end
 
@@ -53,7 +55,7 @@ defmodule HTTPoisonTest do
   end
 
   test "post charlist body" do
-    assert_response(HTTPoison.post("localhost:4002/post", 'test'), fn response ->
+    assert_response(HTTPoison.post("localhost:4002/post", ~c"test"), fn response ->
       assert Request.to_curl(response.request) == {:ok, "curl -X POST http://localhost:4002/post"}
     end)
   end
@@ -233,7 +235,7 @@ defmodule HTTPoisonTest do
   end
 
   test "char list URL" do
-    assert_response(HTTPoison.head('localhost:4002/get'), fn response ->
+    assert_response(HTTPoison.head(~c"localhost:4002/get"), fn response ->
       assert Request.to_curl(response.request) ==
                {:ok, "curl -X HEAD http://localhost:4002/get"}
     end)


### PR DESCRIPTION
Adds the `location: :keep` option to the `quote` in the `__using__/1` macro. These gives better stack traces if and when unexpected errors are raised somewhere in the code. Otherwise the stack tops out at `use HTTPoison.Base` in `HTTPoison` or whever the base is being used.

The PR also includes:

* updating  `ssl_verify_fun` as otherwise I can't get things to compile (at least with Elixir 1.5 / Erlang 26 on OS X and Ubuntu)
* Fixed a couple of tests that I think are failing for me because of Map key ordering changing with Elixir 1.5 (or is it Erlang 26?)

Oh, and it looks like `mix format` has gone and changed a bunch of charlist strings to use the ~c sigil. ¯\\_(ツ)_/¯ . I can revert that if you like.

"test ssl config tests https scheme" in `HTTPoisonTest` is still failing in Elixir 1.5 but I don't know why. Something to do with `httparrot` and ssl.

