### PR TITLE
The Base.request!/1 return value is not wrapped in a ok-tuple

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -427,7 +427,7 @@ defmodule HTTPoison.Base do
       response in case of a successful request, raising an exception in case the
       request fails.
       """
-      @spec request!(Request.t()) :: {:ok, Response.t() | AsyncResponse.t() | MaybeRedirect.t()}
+      @spec request!(Request.t()) :: Response.t() | AsyncResponse.t() | MaybeRedirect.t()
       def request!(%Request{} = request) do
         case request(request) do
           {:ok, response} -> response


### PR DESCRIPTION
This PR is a fix of the typespec for Base.request!/1. The return value is not supposed to be wrapped in a ok-tuple.