### PR TITLE
`request!/1` invalid spec

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -427,7 +427,7 @@ defmodule HTTPoison.Base do
       response in case of a successful request, raising an exception in case the
       request fails.
       """
-      @spec request!(Request.t()) :: {:ok, Response.t() | AsyncResponse.t() | MaybeRedirect.t()}
+      @spec request!(Request.t()) :: Response.t() | AsyncResponse.t() | MaybeRedirect.t()
       def request!(%Request{} = request) do
         case request(request) do
           {:ok, response} -> response


### PR DESCRIPTION
I upgraded to version 2.2.0 and started getting the following dialyzer error:

```
lib/dialyzer_test/client.ex:2: Invalid type specification for function 'Elixir.DialyzerTest.Client':'request!'/1.
 The success typing is 'Elixir.DialyzerTest.Client':'request!'(#{'__struct__':='Elixir.HTTPoison.Request', 'body':=_, 'headers':=_, 'method':='delete' | 'get' | 'head' | 'options' | 'patch' | 'post' | 'put', 'options':=_, 'params':=_, 'url':=binary()}) -> #{'__struct__':='Elixir.HTTPoison.AsyncResponse' | 'Elixir.HTTPoison.MaybeRedirect' | 'Elixir.HTTPoison.Response', 'body'=>_, 'headers'=>[any()], 'id'=>reference(), 'redirect_url'=>_, 'request'=>#{'__struct__':='Elixir.HTTPoison.Request', 'body':=_, 'headers':=_, 'method':='delete' | 'get' | 'head' | 'options' | 'patch' | 'post' | 'put', 'options':=_, 'params':=_, 'url':=binary()}, 'request_url'=>_, 'status_code'=>integer()}
 But the spec is 'Elixir.DialyzerTest.Client':'request!'('Elixir.HTTPoison.Request':t()) -> {'ok','Elixir.HTTPoison.Response':t() | 'Elixir.HTTPoison.AsyncResponse':t() | 'Elixir.HTTPoison.MaybeRedirect':t()}
 The return types do not overlap
 ```

This seems to fix it