### PR TITLE
This PR fixes Case clause error on timeout #496

### DIFF
--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -932,6 +932,9 @@ defmodule HTTPoison.Base do
 
       {:error, reason} ->
         {:error, %Error{reason: reason}}
+
+      {:connect_error, {:error, reason}} ->
+        {:error, %Error{reason: reason}}
     end
   end
 


### PR DESCRIPTION
On connection timeout receives the error below:

```
** (CaseClauseError) no case clause matching: {:connect_error, {:error, :timeout}}
    (httpoison 2.2.2) lib/httpoison/base.ex:888: HTTPoison.Base.request/6
```