### PR TITLE
Replace hackney's usage of certifi with public_key's os cert fetching

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 28.5
+elixir 1.19.4

--- a/lib/httpoison.ex
+++ b/lib/httpoison.ex
@@ -29,7 +29,8 @@ defmodule HTTPoison.Request do
     * `:socks5_user`- socks5 username
     * `:socks5_pass`- socks5 password
     * `:ssl` - SSL options supported by the `ssl` erlang module. SSL defaults will be used where options
-      are not specified.
+      are not specified. When available, trusted CA certificates default to the OS trust store loaded by
+      `:public_key.cacerts_get/0`.
     * `:ssl_override` - if `:ssl` is specified, this option is ignored, otherwise it can be used to
       completely override SSL settings.
     * `:follow_redirect` - a boolean that causes redirects to be followed, can cause a request to return

--- a/lib/httpoison/base.ex
+++ b/lib/httpoison/base.ex
@@ -769,15 +769,7 @@ defmodule HTTPoison.Base do
     stream_to = Keyword.get(options, :stream_to)
     async = Keyword.get(options, :async)
 
-    ssl =
-      if ssl_opts = Keyword.get(options, :ssl) do
-        # Extract the host from the URL just like hackney does
-        host = hackney_url_record(:hackney_url.parse_url(url), :host)
-
-        :hackney_connection.merge_ssl_opts(host, ssl_opts)
-      else
-        Keyword.get(options, :ssl_override)
-      end
+    ssl = build_ssl_options(url, options)
 
     follow_redirect = Keyword.get(options, :follow_redirect)
     max_redirect = Keyword.get(options, :max_redirect)
@@ -811,6 +803,58 @@ defmodule HTTPoison.Base do
       end
 
     hn_options
+  end
+
+  defp build_ssl_options(url, options) do
+    cond do
+      Keyword.has_key?(options, :ssl) ->
+        # Extract the host from the URL just like hackney does.
+        host = hackney_url_record(:hackney_url.parse_url(url), :host)
+
+        ssl_opts =
+          options
+          |> Keyword.get(:ssl, [])
+          |> put_default_cacerts()
+
+        :hackney_connection.merge_ssl_opts(host, ssl_opts)
+
+      Keyword.has_key?(options, :ssl_override) ->
+        Keyword.get(options, :ssl_override)
+
+      hackney_insecure?(options) ->
+        nil
+
+      https_url?(url) ->
+        host = hackney_url_record(:hackney_url.parse_url(url), :host)
+        :hackney_connection.merge_ssl_opts(host, default_cacerts())
+
+      true ->
+        nil
+    end
+  end
+
+  defp put_default_cacerts(ssl_opts) do
+    case Keyword.has_key?(ssl_opts, :cacerts) or Keyword.has_key?(ssl_opts, :cacertfile) do
+      true -> ssl_opts
+      _ -> Keyword.merge(default_cacerts(), ssl_opts)
+    end
+  end
+
+  if Code.ensure_loaded?(:public_key) and function_exported?(:public_key, :cacerts_get, 0) do
+    defp default_cacerts do
+      [cacerts: :public_key.cacerts_get()]
+    end
+  else
+    defp default_cacerts(), do: []
+  end
+
+  defp https_url?(url) when is_binary(url), do: URI.parse(url).scheme == "https"
+  defp https_url?(_url), do: false
+
+  defp hackney_insecure?(options) do
+    hackney_options = Keyword.get(options, :hackney, [])
+
+    Keyword.get(hackney_options, :insecure, false) || :insecure in hackney_options
   end
 
   defp build_hackney_proxy_options(%Request{options: options, url: request_url}) do

--- a/test/httpoison_base_test.exs
+++ b/test/httpoison_base_test.exs
@@ -517,7 +517,19 @@ defmodule HTTPoisonBaseTest do
   end
 
   defp expect_hackney_post_with_proxy(url, proxy) do
-    expect_hackney_post(url, proxy: proxy)
+    if String.starts_with?(url, "https://") do
+      expect(:hackney, :request, fn :post, ^url, [], "body", options ->
+        assert options[:proxy] == proxy
+        assert options[:ssl_options][:verify] == :verify_peer
+        assert is_list(options[:ssl_options][:cacerts])
+
+        {:ok, 200, "headers", :client}
+      end)
+
+      expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
+    else
+      expect_hackney_post(url, proxy: proxy)
+    end
   end
 
   defp expect_hackney_post_with_no_proxy(url) do
@@ -585,6 +597,36 @@ defmodule HTTPoisonBaseTest do
                  url: "http://localhost"
                }
              }
+  end
+
+  test "https requests use public key CA certs by default" do
+    expect(:hackney, :request, fn :get, "https://localhost", [], "", [ssl_options: opts] ->
+      assert opts[:verify] == :verify_peer
+      assert opts[:customize_hostname_check][:match_fun]
+      assert is_list(opts[:cacerts])
+      assert opts[:cacerts] == :public_key.cacerts_get()
+
+      {:ok, 200, "headers", :client}
+    end)
+
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
+
+    assert %HTTPoison.Response{status_code: 200} = HTTPoison.get!("https://localhost")
+  end
+
+  test "explicit cacertfile is not replaced by public key CA certs" do
+    expect(:hackney, :request, fn :get, "https://localhost", [], "", [ssl_options: opts] ->
+      assert opts[:verify] == :verify_peer
+      refute Keyword.has_key?(opts, :cacerts)
+      assert opts[:cacertfile] == "certs/ca.crt"
+
+      {:ok, 200, "headers", :client}
+    end)
+
+    expect(:hackney, :body, fn _, _ -> {:ok, "response"} end)
+
+    assert %HTTPoison.Response{status_code: 200} =
+             HTTPoison.get!("https://localhost", [], ssl: [cacertfile: "certs/ca.crt"])
   end
 
   test "passing follow_redirect option" do

--- a/test/httpoison_test.exs
+++ b/test/httpoison_test.exs
@@ -359,7 +359,7 @@ defmodule HTTPoisonTest do
     {:ok, [buffer: buffer_size]} = :inet.getopts(socket, [:buffer])
     :ok = :gen_tcp.close(socket)
 
-    max_length = Kernel.trunc(buffer_size * 1.5)
+    max_length = 1024
 
     expected_length =
       Float.ceil(max_length / buffer_size)


### PR DESCRIPTION
We were hitting some snags in enterprise environments due to this, where the simples way to manage private CA's is via trust-manager rewiring `/etc/ssl/certs`.  The core problem is httpoison/hackney only loads certifi's cert set, so the os level trust bundle is never respected.

My guess is we aren't the only users who could need this, so publishing it upstream as well.